### PR TITLE
Give correct HTTP status code when login fail

### DIFF
--- a/priv/templates/coherence.install/controllers/coherence/session_controller.ex
+++ b/priv/templates/coherence.install/controllers/coherence/session_controller.ex
@@ -87,11 +87,13 @@ defmodule <%= base %>.Coherence.SessionController do
           conn
           |> put_flash(:error, "Too many failed login attempts. Account has been locked.")
           |> assign(:locked, true)
+          |> put_status(423)
           |> render("new.html", [{login_field, ""}, remember: rememberable_enabled?])
         end
       else
         conn
         |> put_flash(:error, "You must confirm your account before you can login.")
+        |> put_status(406)
         |> render("new.html", [{login_field, login}, remember: rememberable_enabled?])
       end
     else
@@ -99,6 +101,7 @@ defmodule <%= base %>.Coherence.SessionController do
       |> failed_login(user, lockable?)
       |> put_layout({Coherence.LayoutView, "app.html"})
       |> put_view(Coherence.SessionView)
+      |> put_status(401)
       |> render(:new, [{login_field, login}, remember: rememberable_enabled?])
     end
   end

--- a/web/controllers/session_controller.ex
+++ b/web/controllers/session_controller.ex
@@ -87,11 +87,13 @@ defmodule Coherence.SessionController do
           conn
           |> put_flash(:error, "Too many failed login attempts. Account has been locked.")
           |> assign(:locked, true)
+          |> put_status(423)
           |> render("new.html", [{login_field, ""}, remember: rememberable_enabled?])
         end
       else
         conn
         |> put_flash(:error, "You must confirm your account before you can login.")
+        |> put_status(406)
         |> render("new.html", [{login_field, login}, remember: rememberable_enabled?])
       end
     else
@@ -99,6 +101,7 @@ defmodule Coherence.SessionController do
       |> failed_login(user, lockable?)
       |> put_layout({Coherence.LayoutView, "app.html"})
       |> put_view(Coherence.SessionView)
+      |> put_status(401)
       |> render(:new, [{login_field, login}, remember: rememberable_enabled?])
     end
   end


### PR DESCRIPTION
Improvement for this issue https://github.com/smpallen99/coherence/issues/64

<img width="669" alt="screen shot 2016-10-04 at 9 49 22 pm" src="https://cloud.githubusercontent.com/assets/2282642/19079037/6e48193c-8a7c-11e6-9ed1-f4d229c8e50b.png">

Tested and seem work well on my local