### PR TITLE
Fix app-specific module not being loaded on login callback

### DIFF
--- a/lib/coherence/plugs/authorization/session.ex
+++ b/lib/coherence/plugs/authorization/session.ex
@@ -113,7 +113,7 @@ defmodule Coherence.Authentication.Session do
     module = Application.get_env(:coherence, :module)
     |> Module.concat(Coherence.SessionController)
 
-    if :erlang.function_exported(module, :login_callback, 1) do
+    if function_exported?(module, :login_callback, 1) do
       &module.login_callback/1
     else
       &Coherence.SessionController.login_callback/1


### PR DESCRIPTION
When using custom session controllers in tests, `Session.default_login_callback/0` seems to fail because the controller module isn't loaded yet.

However, I don't understand how `Kernel.function_exported?/3` fixes this for me since the [docs](http://elixir-lang.org/docs/stable/elixir/Kernel.html#function_exported?/3) warns us there are no guarantees unless `Code.ensure_loaded/1` is used and it just delegates to the `:erlang` function anyway.

Using:

- Elixir v1.3.2
- Coherence v0.3.0