### PR TITLE
Ensure local module is loaded on login callback

### DIFF
--- a/lib/coherence/plugs/authorization/session.ex
+++ b/lib/coherence/plugs/authorization/session.ex
@@ -113,7 +113,9 @@ defmodule Coherence.Authentication.Session do
     module = Application.get_env(:coherence, :module)
     |> Module.concat(Coherence.SessionController)
 
-    if :erlang.function_exported(module, :login_callback, 1) do
+    Code.ensure_loaded module
+
+    if function_exported?(module, :login_callback, 1) do
       &module.login_callback/1
     else
       &Coherence.SessionController.login_callback/1


### PR DESCRIPTION
The module resolution in `Session.default_login_callback/0` is non-deterministic. Please refer to my other PR https://github.com/smpallen99/coherence/pull/75.