### PR TITLE
'ever ride' -> 'override' typo

### DIFF
--- a/lib/coherence/redirects.ex
+++ b/lib/coherence/redirects.ex
@@ -25,7 +25,7 @@ defmodule Redirects do
   * confirmation_edit/2
   * confirmation_edit_error/2
 
-  You can ever ride any of the functions to customize the redirect path. Each
+  You can override any of the functions to customize the redirect path. Each
   function is passed the `conn` and `params` arguments from the controller.
 
   ## Examples

--- a/priv/templates/coherence.install/controllers/coherence/redirects.ex
+++ b/priv/templates/coherence.install/controllers/coherence/redirects.ex
@@ -24,7 +24,7 @@ defmodule Coherence.Redirects do
   * confirmation_edit/2
   * confirmation_edit_error/2
 
-  You can ever ride any of the functions to customize the redirect path. Each
+  You can override any of the functions to customize the redirect path. Each
   function is passed the `conn` and `params` arguments from the controller.
 
   ## Examples

--- a/web/controllers/redirect.ex
+++ b/web/controllers/redirect.ex
@@ -24,7 +24,7 @@ defmodule Coherence.Redirects do
   * confirmation_edit/2
   * confirmation_edit_error/2
 
-  You can ever ride any of the functions to customize the redirect path. Each
+  You can override any of the functions to customize the redirect path. Each
   function is passed the `conn` and `params` arguments from the controller.
 
   ## Examples


### PR DESCRIPTION
Just a typo fix for "ever ride".