### PR TITLE
Add templates customization section

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,83 @@ end
 
 See the documentation for further details.
 
+
+### Customizing layout
+By default coherence uses own layout from package, that can be installed to `web/templates/coherence/layout/app.html.eex`.
+
+If you want to customize coherence controllers layout, you can follow different approaches:
+
+* Edit layout at `web/templates/coherence/layout/app.html.eex`. In this case, unless authentication layout differes - you will get code duplication.
+
+* Install coherence controllers to application and edit them, to use layout module different from `Coherence.LayoutView`
+
+* Edit `web/views/coherence/layout_view.ex`:
+
+  replace 
+```elixir
+  use ContactDemo.Coherence.Web, :view
+```
+with
+```elixir
+  use Phoenix.View, root: "web/templates"
+  # Import convenience functions from controllers
+  import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, view_module: 1]
+
+  # Use all HTML functionality (forms, tags, etc)
+  use Phoenix.HTML
+
+  import ContactDemo.Router.Helpers
+  import ContactDemo.ErrorHelpers
+  import ContactDemo.Gettext
+  import ContactDemo.Coherence.ViewHelpers
+```
+This approach will require to move also all other coherence templates to top level templates directory `web/templates`
+
+* And the last solution is to edit `web/coherence_web.ex` to allow it to setup which templates directory specific view should use:
+```elixir
+defmodule ExBlog.Coherence.Web do
+  # add default coherence templates path
+  @template_path "web/templates/coherence"
+
+  # using default path unless user provides one explicitly
+  def view(template_path \\ @template_path) do
+    quote do
+      use Phoenix.View, root: unquote(template_path)
+      # Import convenience functions from controllers
+      import Phoenix.Controller, only: [get_csrf_token: 0, get_flash: 2, view_module: 1]
+
+      # Use all HTML functionality (forms, tags, etc)
+      use Phoenix.HTML
+
+      import ExBlog.Router.Helpers
+      import ExBlog.ErrorHelpers
+      import ExBlog.Gettext
+      import ExBlog.Coherence.ViewHelpers
+    end
+  end
+
+  @doc """
+  When used, dispatch to the appropriate controller/view/etc.
+  """
+
+  # 
+  defmacro __using__(which) when is_atom(which) do
+    apply(__MODULE__, which, args)
+  end
+  defmacro __using__([which | args]) do
+    apply(__MODULE__, which, args)
+  end
+end
+```
+After that you can override templates directory for desired view module:
+
+```elixir
+defmodule Coherence.LayoutView do
+  use ExBlog.Coherence.Web, [:view, "web/templates"]
+  import ExBlog.LayoutView, only: [blog_header: 2, page_title: 1]
+end
+```
+
 ## Customizing User Changeset
 
 The User model changeset used by Coherence can be customized for each Coherence controller. To customize the changeset, set the `changeset` config option.


### PR DESCRIPTION
As discussed at #26 adding layout customization section to README.

Also I have a couple proposals:

1. Maybe we should use github wiki for documenting package usage? E.g. [devise gem](https://github.com/plataformatec/devise/wiki) has a rich wiki with examples, guides and example applications. Or, alternatively we could add docs directory to project that will contain *.md files with such information.

2. In my PR I proposed alternative way of customizing layout. It won't break any existing installations of package, so, probably we could merge `web/coherence_web.ex` changes.
@smpallen99 any thoughts?
If you'll accept such solution - I could make separate PR for that.