### PR TITLE
fix typo in coherence.ex @moduledoc

### DIFF
--- a/lib/coherence.ex
+++ b/lib/coherence.ex
@@ -62,7 +62,7 @@ defmodule Coherence do
 
   ### Confirmable
 
-  Requires a new account be conformed. During registration, a conformation token is generated and sent to the registering email. This link must be clicked before the user can sign-in.
+  Requires a new account be conformed. During registration, a confirmation token is generated and sent to the registering email. This link must be clicked before the user can sign-in.
 
   Provides `edit` action for the `/confirmations` route.
 


### PR DESCRIPTION
While skimming through the sources I just found a typo (i.e. `conformation`) inside the `@moduledoc` of `coherence.ex`. I suppose it should have been `confirmation`.