### PR TITLE
Modules should have a @moduledoc tag

### DIFF
--- a/priv/templates/coherence.install/coherence_web.ex
+++ b/priv/templates/coherence.install/coherence_web.ex
@@ -1,4 +1,5 @@
 defmodule <%= base %>.Coherence.Web do
+  @moduledoc false
 
   def view do
     quote do

--- a/priv/templates/coherence.install/emails/coherence/coherence_mailer.ex
+++ b/priv/templates/coherence.install/emails/coherence/coherence_mailer.ex
@@ -1,3 +1,4 @@
 defmodule <%= base %>.Coherence.Mailer do
+  @moduledoc false
   use Swoosh.Mailer, otp_app: :coherence
 end

--- a/priv/templates/coherence.install/emails/coherence/user_email.ex
+++ b/priv/templates/coherence.install/emails/coherence/user_email.ex
@@ -1,6 +1,7 @@
 Code.ensure_loaded Phoenix.Swoosh
 
 defmodule <%= base %>.Coherence.UserEmail do
+  @moduledoc false
   use Phoenix.Swoosh, view: Coherence.EmailView, layout: {Coherence.LayoutView, :email}
   alias Swoosh.Email
   require Logger

--- a/priv/templates/coherence.install/models/coherence/user.ex
+++ b/priv/templates/coherence.install/models/coherence/user.ex
@@ -1,4 +1,5 @@
 defmodule <%= user_schema %> do
+  @moduledoc false
   use <%= base %>.Web, :model
   use Coherence.Schema
 


### PR DESCRIPTION
A few of the installed templates generate "Modules should have a @moduledoc tag" code readability issues with [credo](https://github.com/rrrene/credo); this fixes them.