### PR TITLE
How to support UUIDs for users?

### DIFF
--- a/web/web.ex
+++ b/web/web.ex
@@ -7,6 +7,9 @@ defmodule Coherence.Web do
       import Ecto
       import Ecto.Changeset
       import Ecto.Query, only: [from: 1, from: 2]
+
+      @primary_key {:id, :binary_id, autogenerate: true}
+      @foreign_key_type :binary_id
     end
   end
 


### PR DESCRIPTION
Hello! Thanks for your excellent library.

I open this PR not as an actual suggestion to merge this code, but to ask whether you might consider supporting UUIDs as the primary key for the user model. I want to use them in an application for privacy reasons so I created this fork to permit the rememberable feature to work properly. Without this change, I could log in, but “Remember Me” would trigger an error because the  user changeset validation was expecting an integer ID, not a UUID.

Do you think there‘s a way to make this configurable? I’m still pretty new to Elixir and suspect my ideas would be less than idiomatic.

Apart from this fork, in my own application, I needed to change the Coherence-generated migrations, but that was it. Nicely designed!

The test failure is expected, since I didn’t change of the rest of the code that’s looking for integer IDs.