### PR TITLE
Make “Remember Me?” clickable

### DIFF
--- a/priv/templates/coherence.install/templates/coherence/session/new.html.eex
+++ b/priv/templates/coherence.install/templates/coherence/session/new.html.eex
@@ -17,7 +17,8 @@
 
   <%%= if @remember do %>
     <div class="form-group">
-      <input type="checkbox"  name="remember"> Remember Me?
+      <input type="checkbox"  name="remember" id="remember">
+      <label for="remember">Remember Me?</label>
     </div>
     <br />
   <%% end %>


### PR DESCRIPTION
Hey, thanks again for this, it’s saved me so much work.

Here‘s a small UX improvement suggestion, making it possible to click the “Remember Me?” text itself to toggle the checkbox in addition to the checkbox itself.

There’s some debate about whether it’s preferable to put the `input` _inside_ the `label`, which I could do if that’s more appealing to you.

This causes the “Remember Me?” text to become bold, hopefully that‘s okay.