### PR TITLE
Remove warings about missing parentheses for function calls in elxir 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ defmodule MyProject.Router do
   # Add this block
   scope "/" do
     pipe_through :browser
-    coherence_routes
+    coherence_routes()
   end
 
   # Add this block

--- a/lib/mix/tasks/coherence.make_templates.ex
+++ b/lib/mix/tasks/coherence.make_templates.ex
@@ -23,7 +23,7 @@ defmodule Mix.Tasks.Coherence.MakeTemplates do
   @dest_path Path.join(~w(. priv templates coherence.install controllers coherence))
 
   def run(_) do
-    controller_files
+    controller_files()
     |> Enum.each(fn fname ->
       contents = Path.join(@source_path, fname)
       |> File.read!

--- a/priv/templates/coherence.install/emails/coherence/user_email.ex
+++ b/priv/templates/coherence.install/emails/coherence/user_email.ex
@@ -11,36 +11,36 @@ defmodule <%= base %>.Coherence.UserEmail do
 
   def password(user, url) do
     %Email{}
-    |> from(from_email)
+    |> from(from_email())
     |> to(user_email(user))
-    |> add_reply_to
-    |> subject("#{site_name} - Reset password instructions")
+    |> add_reply_to()
+    |> subject("#{site_name()} - Reset password instructions")
     |> render_body("password.html", %{url: url, name: first_name(user.name)})
   end
 
   def confirmation(user, url) do
     %Email{}
-    |> from(from_email)
+    |> from(from_email())
     |> to(user_email(user))
-    |> add_reply_to
-    |> subject("#{site_name} - Confirm your new account")
+    |> add_reply_to()
+    |> subject("#{site_name()} - Confirm your new account")
     |> render_body("confirmation.html", %{url: url, name: first_name(user.name)})
   end
 
   def invitation(invitation, url) do
     %Email{}
-    |> from(from_email)
+    |> from(from_email())
     |> to(user_email(invitation))
-    |> add_reply_to
-    |> subject("#{site_name} - Invitation to create a new account")
+    |> add_reply_to()
+    |> subject("#{site_name()} - Invitation to create a new account")
     |> render_body("invitation.html", %{url: url, name: first_name(invitation.name)})
   end
 
   def unlock(user, url) do
     %Email{}
-    |> from(from_email)
+    |> from(from_email())
     |> to(user_email(user))
-    |> add_reply_to
+    |> add_reply_to()
     |> subject("#{site_name} - Unlock Instructions")
     |> render_body("unlock.html", %{url: url, name: first_name(user.name)})
   end
@@ -48,7 +48,7 @@ defmodule <%= base %>.Coherence.UserEmail do
   defp add_reply_to(mail) do
     case Coherence.Config.email_reply_to do
       nil              -> mail
-      true             -> reply_to mail, from_email
+      true             -> reply_to mail, from_email()
       address          -> reply_to mail, address
     end
   end

--- a/priv/templates/coherence.install/models/coherence/user.ex
+++ b/priv/templates/coherence.install/models/coherence/user.ex
@@ -6,14 +6,14 @@ defmodule <%= user_schema %> do
   schema "<%= user_table_name %>" do
     field :name, :string
     field :email, :string
-    coherence_schema
+    coherence_schema()
 
-    timestamps
+    timestamps()
   end
 
   def changeset(model, params \\ %{}) do
     model
-    |> cast(params, [:name, :email] ++ coherence_fields)
+    |> cast(params, [:name, :email] ++ coherence_fields())
     |> validate_required([:name, :email])
     |> validate_format(:email, ~r/@/)
     |> unique_constraint(:email)


### PR DESCRIPTION
This PR should remove some warings like following in elixir 1.4

```
warning: variable "timestamps" does not exist and is being expanded to "timestamps()",
please use parentheses to remove the ambiguity or change the variable name
```