### PR TITLE
Adds support for binary_ids

### DIFF
--- a/lib/coherence/config.ex
+++ b/lib/coherence/config.ex
@@ -162,6 +162,14 @@ defmodule Coherence.Config do
     end)
   end
 
+  @doc """
+  Test if Phoenix is configured to use binary ids by default
+  """
+  @spec use_binary_id?() :: boolean
+  def use_binary_id? do
+    !!Application.get_env(:phoenix, :generators)[:binary_id]
+  end
+
   defp has_any_option?(fun) do
     if opts() == :all do
       true

--- a/lib/mix/tasks/coherence.install.ex
+++ b/lib/mix/tasks/coherence.install.ex
@@ -4,6 +4,7 @@ defmodule Mix.Tasks.Coherence.Install do
   import Macro, only: [camelize: 1, underscore: 1]
   import Mix.Generator
   import Mix.Ecto
+  import Coherence.Config, only: [use_binary_id?: 0]
   import Coherence.Mix.Utils
 
   @shortdoc "Configure the Coherence Package"
@@ -497,8 +498,6 @@ config :coherence, #{base}.Coherence.Mailer,
     type_hint = if use_binary_id?(), do: ", type: :binary_id", else: ""
     "references(:#{table_name}, on_delete: :delete_all#{type_hint})"
   end
-
-  defp use_binary_id?, do: !!Application.get_env(:phoenix, :generators)[:binary_id]
 
   ################
   # Web

--- a/web/web.ex
+++ b/web/web.ex
@@ -7,6 +7,11 @@ defmodule Coherence.Web do
       import Ecto
       import Ecto.Changeset
       import Ecto.Query, only: [from: 1, from: 2]
+
+      if Coherence.Config.use_binary_id? do
+        @primary_key {:id, :binary_id, autogenerate: true}
+        @foreign_key_type :binary_id
+      end
     end
   end
 


### PR DESCRIPTION
This commit adds support for binary ids in the migrations of the `coherence.install` mix task as already discussed in #125.

Instead of another flag for the installer, I decided to go with the official phoenix configuration which already provides a way to set the way ids are handled by default.

This has some advantages. For example the generated model does not need any special attributes, if the phoenix application is properly configured. You can add the configuration manually in your `config.exs`:

```elixir
# Configure phoenix generators
config :phoenix, :generators,
  binary_id: true
```

or just pass the `--binary-id` flag when bootstrapping a new phoenix application.

```
mix phoenix.new --binary-id
```

If the phoenix application is configured to default to binary ids, the generator of coherence now will respect this when generating the migrations. This affects the `create` function as well as the `references` function in the migration.

Please let me know what you think! I am happy about any kind of feedback!

Best,
Christian