### PR TITLE
Always call a dedicated changeset/3 function for password resets

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ defmodule MyProject.User do
     |> validate_format(:email, ~r/@/)
     |> validate_coherence(params)                         # Add this
   end
+
+  def changeset(model, params, :password) do
+    model
+    |> cast(params, ~w(password password_confirmation reset_password_token reset_password_sent_at))
+    |> validate_coherence_password_reset(params)
+  end
 end
 ```
 

--- a/lib/coherence/schema.ex
+++ b/lib/coherence/schema.ex
@@ -75,6 +75,12 @@ defmodule Coherence.Schema do
           |> unique_constraint(:email)
           |> validate_coherence(params)
         end
+
+        def changeset(model, params, :password) do
+          model
+          |> cast(params, ~w(password password_confirmation reset_password_token reset_password_sent_at))
+          |> validate_coherence_password_reset(params)
+        end
       end
 
   """
@@ -238,6 +244,12 @@ defmodule Coherence.Schema do
           changeset
           |> validate_length(:password, min: 4)
           |> validate_current_password(params)
+          |> validate_password(params)
+        end
+
+        def validate_coherence_password_reset(changeset, params) do
+          changeset
+          |> validate_length(:password, min: 4)
           |> validate_password(params)
         end
 

--- a/lib/mix/tasks/coherence.install.ex
+++ b/lib/mix/tasks/coherence.install.ex
@@ -637,6 +637,12 @@ config :coherence, #{base}.Coherence.Mailer,
         |> unique_constraint(:email)
         |> validate_coherence(params)             # Add this
       end
+
+      def changeset(model, params, :password) do
+        model
+        |> cast(params, ~w(password password_confirmation reset_password_token reset_password_sent_at))
+        |> validate_coherence_password_reset(params)
+      end
     end
     """
   defp schema_instructions(_), do: ""

--- a/priv/templates/coherence.install/models/coherence/user.ex
+++ b/priv/templates/coherence.install/models/coherence/user.ex
@@ -19,4 +19,10 @@ defmodule <%= user_schema %> do
     |> unique_constraint(:email)
     |> validate_coherence(params)
   end
+
+  def changeset(model, params, :password) do
+    model
+    |> cast(params, ~w(password password_confirmation reset_password_token reset_password_sent_at))
+    |> validate_coherence_password_reset(params)
+  end
 end

--- a/test/controllers/password_controller_test.exs
+++ b/test/controllers/password_controller_test.exs
@@ -91,19 +91,18 @@ defmodule CoherenceTest.PasswordController do
       assert user.reset_password_sent_at == old_sent_at
     end
 
-    test "valid token has expired", %{conn: conn} do
+    test "valid token has expired, reset token gets removed", %{conn: conn} do
       {:ok, sent_at} = Ecto.DateTime.cast("2016-01-01 00:00:00")
       token = random_string 48
       user = insert_user(%{reset_password_sent_at: sent_at, reset_password_token: token})
       old_password_hash = user.password_hash
-      old_sent_at = user.reset_password_sent_at
       params = %{"password" => %{reset_password_token: token, password: "123123", password_confirmation: "123123"}}
       put(conn, password_path(conn, :update, user.id), params)
       user = Repo.get!(TestCoherence.User, user.id)
 
       assert old_password_hash == user.password_hash
-      assert user.reset_password_token == token
-      assert user.reset_password_sent_at == old_sent_at
+      assert user.reset_password_token == nil
+      assert user.reset_password_sent_at == nil
     end
   end
 

--- a/test/controllers/password_controller_test.exs
+++ b/test/controllers/password_controller_test.exs
@@ -64,6 +64,49 @@ defmodule CoherenceTest.PasswordController do
     end
   end
 
+  describe "update" do
+    test "valid token", %{conn: conn} do
+      token = random_string 48
+      user = insert_user(%{reset_password_sent_at: Ecto.DateTime.utc, reset_password_token: token})
+      old_password_hash = user.password_hash
+      params = %{"password" => %{reset_password_token: token, password: "123123", password_confirmation: "123123"}}
+      put(conn, password_path(conn, :update, user.id), params)
+      user = Repo.get!(TestCoherence.User, user.id)
+      refute old_password_hash == user.password_hash
+      assert user.reset_password_token == nil
+      assert user.reset_password_sent_at == nil
+    end
+
+    test "invalid reset password token", %{conn: conn} do
+      token = random_string 48
+      user = insert_user(%{reset_password_sent_at: Ecto.DateTime.utc, reset_password_token: token})
+      old_password_hash = user.password_hash
+      old_sent_at = user.reset_password_sent_at
+      params = %{"password" => %{reset_password_token: "1234567890", password: "123123", password_confirmation: "123123"}}
+      put(conn, password_path(conn, :update, user.id), params)
+      user = Repo.get!(TestCoherence.User, user.id)
+
+      assert old_password_hash == user.password_hash
+      assert user.reset_password_token == token
+      assert user.reset_password_sent_at == old_sent_at
+    end
+
+    test "valid token has expired", %{conn: conn} do
+      {:ok, sent_at} = Ecto.DateTime.cast("2016-01-01 00:00:00")
+      token = random_string 48
+      user = insert_user(%{reset_password_sent_at: sent_at, reset_password_token: token})
+      old_password_hash = user.password_hash
+      old_sent_at = user.reset_password_sent_at
+      params = %{"password" => %{reset_password_token: token, password: "123123", password_confirmation: "123123"}}
+      put(conn, password_path(conn, :update, user.id), params)
+      user = Repo.get!(TestCoherence.User, user.id)
+
+      assert old_password_hash == user.password_hash
+      assert user.reset_password_token == token
+      assert user.reset_password_sent_at == old_sent_at
+    end
+  end
+
   describe "trackable table" do
     setup [:setup_trackable_table]
 

--- a/test/support/schema.exs
+++ b/test/support/schema.exs
@@ -22,6 +22,12 @@ defmodule TestCoherence.User do
     |> unique_constraint(:email)
     |> validate_coherence(params)
   end
+
+  def changeset(model, params, :password) do
+    model
+    |> cast(params, ~w(password password_confirmation reset_password_token reset_password_sent_at))
+    |> validate_coherence_password_reset(params)
+  end
 end
 
 defmodule TestCoherence.Invitation do
@@ -67,6 +73,12 @@ defmodule TestCoherence.Account do
     |> cast(params, @required_fields, @optional_fields)
     |> unique_constraint(:email)
     |> validate_coherence(params)
+  end
+
+  def changeset(model, params, :password) do
+    model
+    |> cast(params, ~w(password password_confirmation reset_password_token reset_password_sent_at))
+    |> validate_coherence_password_reset(params)
   end
 end
 

--- a/web/controllers/controller_helpers.ex
+++ b/web/controllers/controller_helpers.ex
@@ -263,7 +263,12 @@ defmodule Coherence.ControllerHelpers do
   end
 
   @spec changeset(atom, module, schema, params) :: changeset
-  def changeset(which, module, model, params \\ %{}) do
+  def changeset(which, module, model, params \\ %{})
+  def changeset(:password, module, model, params) do
+    fun = Application.get_env :coherence, :changeset, :changeset
+    apply module, fun, [model, params, :password]
+  end
+  def changeset(which, module, model, params) do
     {mod, fun, args} = case Application.get_env :coherence, :changeset do
       nil -> {module, :changeset, [model, params]}
       {mod, fun} -> {mod, fun, [model, params, which]}

--- a/web/controllers/password_controller.ex
+++ b/web/controllers/password_controller.ex
@@ -120,18 +120,27 @@ defmodule Coherence.PasswordController do
         |> put_flash(:error, "Invalid reset token")
         |> redirect(to: logged_out_url(conn))
       user ->
-        params = password_params
-        |> clear_password_params
-        cs = Helpers.changeset(:password, user_schema, user, params)
-        case repo.update(cs) do
-          {:ok, user} ->
-            conn
-            |> TrackableService.track_password_reset(user, user_schema.trackable_table?)
-            |> put_flash(:info, "Password updated successfully.")
-            |> redirect_to(:password_update, params)
-          {:error, changeset} ->
-            conn
-            |> render("edit.html", changeset: changeset)
+        if expired? user.reset_password_sent_at, days: Config.reset_token_expire_days do
+          Helpers.changeset(:password, user_schema, user, clear_password_params())
+          |> Config.repo.update
+
+          conn
+          |> put_flash(:error, "Password reset token expired.")
+          |> redirect(to: logged_out_url(conn))
+        else
+          params = password_params
+          |> clear_password_params
+          cs = Helpers.changeset(:password, user_schema, user, params)
+          case repo.update(cs) do
+            {:ok, user} ->
+              conn
+              |> TrackableService.track_password_reset(user, user_schema.trackable_table?)
+              |> put_flash(:info, "Password updated successfully.")
+              |> redirect_to(:password_update, params)
+            {:error, changeset} ->
+              conn
+              |> render("edit.html", changeset: changeset)
+          end
         end
     end
   end
@@ -141,5 +150,4 @@ defmodule Coherence.PasswordController do
     |> Map.put("reset_password_token", nil)
     |> Map.put("reset_password_sent_at", nil)
   end
-
 end


### PR DESCRIPTION
This is my attempt to solve the bug described in https://github.com/smpallen99/coherence/issues/123

Problem:

The setting `require_current_password` does prevent the resetting of passwords using a token. This is, because at the moment the resetting of a password would require a user to know the current password.

My approach to a solution:

I think the cleanest approach would be to provide an extra `changeset/3` function in the model for this particular use case. This is already possible with the `changeset` config setting, but I think it should be done in any case for the password reset use case.

This is just my first stab at it. I would be happy to get some feedback about this approach. :)

Also, while working in this fix, I stumbled over another bug, which I reported in https://github.com/smpallen99/coherence/issues/163

This PR here also contains a failing spec that checks for the proper handling of expired password reset tokens.

Please let me know if this is of any help and if I should continue.

Best,
Christian



