### PR TITLE
set path to redirect to in options

### DIFF
--- a/priv/templates/coherence.install/controllers/coherence/redirects.ex
+++ b/priv/templates/coherence.install/controllers/coherence/redirects.ex
@@ -32,13 +32,13 @@ defmodule Coherence.Redirects do
       import MyProject.Router.Helpers
 
       # override the log out action back to the log in page
-      def session_delete(conn, _), do: redirect(conn, session_path(conn, :new))
+      def session_delete(conn, _), do: redirect(conn, to: session_path(conn, :new))
 
       # redirect the user to the login page after registering
-      def registration_create(conn, _), do: redirect(conn, session_path(conn, :new))
+      def registration_create(conn, _), do: redirect(conn, to: session_path(conn, :new))
 
       # disable the user_return_to feature on login
-      def session_create(conn, _), do: redirect(conn, landing_path(conn, :index))
+      def session_create(conn, _), do: redirect(conn, to: landing_path(conn, :index))
 
   """
   use Redirects
@@ -49,6 +49,6 @@ defmodule Coherence.Redirects do
 
   # Example usage
   # Uncomment the following line to return the user to the login form after logging out
-  # def session_delete(conn, _), do: redirect(conn, session_path(conn, :new))
+  # def session_delete(conn, _), do: redirect(conn, to: session_path(conn, :new))
 
 end


### PR DESCRIPTION
small doc update: `to:` was missing, and is failing (at least for current phoenix version)