### PR TITLE
Fix function name typo in documentation

### DIFF
--- a/lib/coherence/schema.ex
+++ b/lib/coherence/schema.ex
@@ -453,7 +453,7 @@ defmodule Coherence.Schema do
   in your models changeset cast.
 
   For example, for `Coherence.Config.opts == [:authenticatable, :recoverable]`
-  `coherence_fiels/0` will return:
+  `coherence_fields/0` will return:
 
       ~w(password_hash password password_confirmation reset_password_token reset_password_sent_at)
   """


### PR DESCRIPTION
The contributing doc states that every PR should have an issue associated so please just let me know if I need to create one, but I thought maybe it would be just extra noise on the issue tracker for a single character addition docfix. Thanks!