### PR TITLE
Add config option to specify minimum password length Issue#206

### DIFF
--- a/lib/coherence/config.ex
+++ b/lib/coherence/config.ex
@@ -49,6 +49,7 @@ defmodule Coherence.Config do
   * :verify_user_token (fn socket, token -> Phoenix.Token.verify(socket, "user socket", token, max_age: 2 * 7 * 24 * 60 * 60) end
   *                    can also be a 3 element tuple as described above for :token_generator
   * :use_binary_id (false) - Use binary ids.
+  # :minimum_password_length The minimum password length to be accepted. Default value is 4.
 
   ## Examples
 
@@ -104,7 +105,8 @@ defmodule Coherence.Config do
     {:unlock_token_expire_minutes, 5},
     {:session_key, "session_auth"},
     {:rememberable_cookie_expire_hours, 2 * 24},
-    {:async_rememberable?, false}
+    {:async_rememberable?, false},
+    {:minimum_password_length, 4}
   ]
   |> Enum.each(fn
         {key, default} ->

--- a/lib/coherence/schema.ex
+++ b/lib/coherence/schema.ex
@@ -242,14 +242,14 @@ defmodule Coherence.Schema do
 
         def validate_coherence(changeset, params) do
           changeset
-          |> validate_length(:password, min: 4)
+          |> validate_length(:password, min: Config.minimum_password_length)
           |> validate_current_password(params)
           |> validate_password(params)
         end
 
         def validate_coherence_password_reset(changeset, params) do
           changeset
-          |> validate_length(:password, min: 4)
+          |> validate_length(:password, min: Config.minimum_password_length)
           |> validate_password(params)
         end
 

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -35,6 +35,12 @@ defmodule CoherenceTest.Schema do
     cs = User.changeset(%User{}, %{name: "test", email: @email, password: "12345", password_confirmation: "99"})
     refute cs.valid?
   end
+  
+  test "invalidates incorrect password length" do
+    cs = User.changeset(%User{}, %{name: "test", email: @email, password: "123", password_confirmation: "123"})
+    refute cs.valid?
+    assert cs.errors == [password: {"should be at least %{count} character(s)", [count: 4, validation: :length, min: 4]}]
+  end
 
   test "checkpw" do
     params = %{name: "test", email: @email, password: "test", password_confirmation: "test"}


### PR DESCRIPTION
Added an item `minimum_password_length` in the Coherence Config to support custom minimum password lengths. Default length is 4.