### PR TITLE
Messages backend is defined in the web module

### DIFF
--- a/lib/mix/tasks/coh.install.ex
+++ b/lib/mix/tasks/coh.install.ex
@@ -256,7 +256,7 @@ defmodule Mix.Tasks.Coh.Install do
         module: #{config[:base]},
         web_module: #{config[:web_base]},
         router: #{config[:router]},
-        messages_backend: #{config[:base]}.Coherence.Messages,
+        messages_backend: #{config[:web_base]}.Coherence.Messages,
         logged_out_url: "/",
       """
     (config_block <> from_email <> "  opts: #{inspect config[:opts]}\n")


### PR DESCRIPTION
The messages backend is actually created in the Web module rather than the base module, this fixes the generated config to reflect that correctly.