### PR TITLE
Fix the issue with date and :password changeset

### DIFF
--- a/lib/coherence/controllers/controller_helpers.ex
+++ b/lib/coherence/controllers/controller_helpers.ex
@@ -277,12 +277,7 @@ defmodule Coherence.ControllerHelpers do
   end
 
   @spec changeset(atom, module, schema, params) :: changeset
-  def changeset(which, module, model, params \\ %{})
-  def changeset(:password, module, model, params) do
-    fun = Application.get_env :coherence, :changeset, :changeset
-    apply module, fun, [model, params, :password]
-  end
-  def changeset(which, module, model, params) do
+  def changeset(which, module, model, params \\ %{}) do
     {mod, fun, args} = case Application.get_env :coherence, :changeset do
       nil -> {module, :changeset, [model, params]}
       {mod, fun} -> {mod, fun, [model, params, which]}

--- a/lib/coherence/controllers/controller_helpers.ex
+++ b/lib/coherence/controllers/controller_helpers.ex
@@ -130,7 +130,6 @@ defmodule Coherence.ControllerHelpers do
   @spec shift(struct, Keyword.t) :: struct
   def shift(datetime, opts) do
     datetime
-    |> Ecto.DateTime.to_erl
     |> Timex.to_datetime
     |> Timex.shift(opts)
   end


### PR DESCRIPTION
I'm not sure if this issue is specific to my project or not, but I'll share it and hopefully, it helps someone.

Changes on **L133**: `Ecto.DateTime.to_erl` is undefined and date is already NaiveDateTime which works with Timex.
Changes from **L287**: Maybe I'm missing something but I don't get why password deserves a separate code execution path. And it happens to not work with config:
```elixir
config :coherence,
  changeset: {Project.User, :changeset}
```

My dependencies:
```elixir
     {:phoenix, "~> 1.3.0"},
     {:phoenix_ecto, "~> 3.2"},
     {:rethinkdb, "~> 0.4"},
     {:rethinkdb_ecto, "~> 0.7"},
     {:coherence, "~> 0.5"},
     {:timex, "~> 3.1"},
```

Note: I'm using old project structure with phoenix 1.3, and maybe my rethinkdb_ecto driver does something funky with dates  ¯\_(ツ)_/¯