### PR TITLE
Fix documentation for token auth

### DIFF
--- a/lib/coherence/plugs/authorization/token.ex
+++ b/lib/coherence/plugs/authorization/token.ex
@@ -10,7 +10,7 @@ defmodule Coherence.Authentication.Token do
 
     or
 
-      plug Coherence.Authentication.Token, source: :header, param: "X-Auth-Token"
+      plug Coherence.Authentication.Token, source: :header, param: "x-auth-token"
 
     or
 


### PR DESCRIPTION
The documentation at https://hexdocs.pm/coherence/Coherence.Authentication.Token.html shows
```elixir
plug Coherence.Authentication.Token, source: :header, param: "X-Auth-Token"
```
as an example configuration for token auth, but plug downcases all headers, so `X-Auth-Token` will never match anything.