### PR TITLE
Add a Responders behavior to handle json format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,6 +555,11 @@ end
 
 See the documentation for further details.
 
+### Customizing Responders
+
+To customize how application responds to html or json format, you can override methods in the `lib/my_project_web/controllers/coherence/responders/html.ex` or `lib/my_project_web/controllers/coherence/responders/json.ex`.
+
+
 ### Customizing layout
 
 By default coherence uses its own layout which is installed to `lib/my_project_web/templates/coherence/layout/app.html.eex`.

--- a/lib/coherence/controllers/invitation_controller.ex
+++ b/lib/coherence/controllers/invitation_controller.ex
@@ -85,8 +85,7 @@ defmodule Coherence.InvitationController do
                 add_error(changeset, :email,
                   Messages.backend().invitation_already_sent())}
           end
-        conn
-        |> respond_with(:invitation_create_error, %{changeset: changeset})
+        respond_with(conn, :invitation_create_error, %{changeset: changeset})
     end
   end
 
@@ -124,16 +123,15 @@ defmodule Coherence.InvitationController do
     user_schema = Config.user_schema
     case Schemas.get_by_invitation token: token do
       nil ->
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :invitation_create_user_error,
           %{
             error: Messages.backend().invalid_invitation()
           }
         )
       invite ->
-        :invitation
-        |> Controller.changeset(user_schema, user_schema.__struct__, params["user"])
+        Controller.changeset(:invitation, user_schema, user_schema.__struct__, params["user"])
         |> Schemas.create
         |> case do
           {:ok, user} ->
@@ -144,8 +142,8 @@ defmodule Coherence.InvitationController do
               :invitation_create_user_success
             )
           {:error, changeset} ->
-            conn
-            |> respond_with(
+            respond_with(
+              conn,
               :invitation_create_user_error,
               %{
                 changeset: changeset,
@@ -165,8 +163,8 @@ defmodule Coherence.InvitationController do
   def resend(conn, %{"id" => id} = params) do
     case Schemas.get_invitation id do
       nil ->
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :invitation_resend_error,
           %{
             params: params,
@@ -176,8 +174,8 @@ defmodule Coherence.InvitationController do
       invitation ->
         send_user_email :invitation, invitation,
           router_helpers().invitation_url(conn, :edit, invitation.token)
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :invitation_resend_success,
           %{
             params: params,

--- a/lib/coherence/controllers/password_controller.ex
+++ b/lib/coherence/controllers/password_controller.ex
@@ -46,8 +46,8 @@ defmodule Coherence.PasswordController do
     case Schemas.get_user_by_email password_params["email"] do
       nil ->
         changeset = Controller.changeset :password, user_schema, user_schema.__struct__
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :password_create_error,
           %{
             changeset: changeset,
@@ -64,8 +64,8 @@ defmodule Coherence.PasswordController do
 
         if Config.mailer?() do
           send_user_email :password, user, url
-          conn
-          |> respond_with(
+          respond_with(
+            conn,
             :password_create_success,
             %{
               params: params,
@@ -73,8 +73,8 @@ defmodule Coherence.PasswordController do
             }
           )
         else
-          conn
-          |> respond_with(
+          respond_with(
+            conn,
             :password_create_success,
             %{
               params: params,
@@ -124,8 +124,8 @@ defmodule Coherence.PasswordController do
 
     case Schemas.get_by_user reset_password_token: token do
       nil ->
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :password_update_error,
           %{error: Messages.backend().invalid_reset_token()}
         )
@@ -135,8 +135,8 @@ defmodule Coherence.PasswordController do
           |> Controller.changeset(user_schema, user, clear_password_params())
           |> Schemas.update
 
-          conn
-          |> respond_with(
+          respond_with(
+            conn,
             :password_update_error,
             %{error: Messages.backend().password_reset_token_expired()}
           )
@@ -158,8 +158,8 @@ defmodule Coherence.PasswordController do
                 }
               )
             {:error, changeset} ->
-              conn
-              |> respond_with(
+              respond_with(
+                conn,
                 :password_update_error,
                 %{changeset: changeset}
               )

--- a/lib/coherence/controllers/password_controller.ex
+++ b/lib/coherence/controllers/password_controller.ex
@@ -47,8 +47,13 @@ defmodule Coherence.PasswordController do
       nil ->
         changeset = Controller.changeset :password, user_schema, user_schema.__struct__
         conn
-        |> put_flash(:error, Messages.backend().could_not_find_that_email_address())
-        |> render("new.html", changeset: changeset)
+        |> respond_with(
+          :password_create_error,
+          %{
+            changeset: changeset,
+            error: Messages.backend().could_not_find_that_email_address()
+          }
+        )
       user ->
         token = random_string 48
         url = router_helpers().password_url(conn, :edit, token)
@@ -59,11 +64,24 @@ defmodule Coherence.PasswordController do
 
         if Config.mailer?() do
           send_user_email :password, user, url
-          put_flash(conn, :info, Messages.backend().reset_email_sent())
+          conn
+          |> respond_with(
+            :password_create_success,
+            %{
+              params: params,
+              info: Messages.backend().reset_email_sent()
+            }
+          )
         else
-          put_flash(conn, :error, Messages.backend().mailer_required())
+          conn
+          |> respond_with(
+            :password_create_success,
+            %{
+              params: params,
+              error: Messages.backend().mailer_required()
+            }
+          )
         end
-        |> redirect_to(:password_create, params)
     end
   end
 
@@ -107,8 +125,10 @@ defmodule Coherence.PasswordController do
     case Schemas.get_by_user reset_password_token: token do
       nil ->
         conn
-        |> put_flash(:error, Messages.backend().invalid_reset_token())
-        |> redirect(to: logged_out_url(conn))
+        |> respond_with(
+          :password_update_error,
+          %{error: Messages.backend().invalid_reset_token()}
+        )
       user ->
         if expired? user.reset_password_sent_at, days: Config.reset_token_expire_days do
           :password
@@ -116,8 +136,10 @@ defmodule Coherence.PasswordController do
           |> Schemas.update
 
           conn
-          |> put_flash(:error, Messages.backend().password_reset_token_expired())
-          |> redirect(to: logged_out_url(conn))
+          |> respond_with(
+            :password_update_error,
+            %{error: Messages.backend().password_reset_token_expired()}
+          )
         else
           params = clear_password_params password_params
 
@@ -128,10 +150,19 @@ defmodule Coherence.PasswordController do
             {:ok, user} ->
               conn
               |> TrackableService.track_password_reset(user, user_schema.trackable_table?)
-              |> put_flash(:info, Messages.backend().password_updated_successfully())
-              |> redirect_to(:password_update, params)
+              |> respond_with(
+                :password_update_success,
+                %{
+                  params: params,
+                  info: Messages.backend().password_updated_successfully()
+                }
+              )
             {:error, changeset} ->
-              render(conn, "edit.html", changeset: changeset)
+              conn
+              |> respond_with(
+                :password_update_error,
+                %{changeset: changeset}
+              )
           end
         end
     end

--- a/lib/coherence/controllers/registration_controller.ex
+++ b/lib/coherence/controllers/registration_controller.ex
@@ -60,14 +60,12 @@ defmodule Coherence.RegistrationController do
         |> send_confirmation(user, user_schema)
         |> redirect_or_login(user, params, Config.allow_unconfirmed_access_for)
       {:error, changeset} ->
-        conn
-        |> respond_with(:registration_create_error, %{changeset: changeset})
+        respond_with(conn, :registration_create_error, %{changeset: changeset})
     end
   end
 
   defp redirect_or_login(conn, user, params, 0) do
-    conn
-    |> respond_with(:registration_create_success, %{params: params, user: user})
+    respond_with(conn, :registration_create_success, %{params: params, user: user})
   end
   defp redirect_or_login(conn, user, params, _) do
     conn
@@ -117,8 +115,7 @@ defmodule Coherence.RegistrationController do
           }
         )
       {:error, changeset} ->
-        conn
-        |> respond_with(:registration_update_error, %{user: user, changeset: changeset})
+        respond_with(conn, :registration_update_error, %{user: user, changeset: changeset})
     end
   end
 

--- a/lib/coherence/controllers/session_controller.ex
+++ b/lib/coherence/controllers/session_controller.ex
@@ -86,8 +86,8 @@ defmodule Coherence.SessionController do
         do_lockable(conn, login_field, [user, user_schema, remember, lockable?, remember, params],
           user_schema.lockable?() and user_schema.locked?(user))
       else
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :session_create_error,
           %{
             new_bindings: new_bindings,

--- a/lib/coherence/controllers/session_controller.ex
+++ b/lib/coherence/controllers/session_controller.ex
@@ -87,16 +87,19 @@ defmodule Coherence.SessionController do
           user_schema.lockable?() and user_schema.locked?(user))
       else
         conn
-        |> put_flash(:error, Messages.backend().you_must_confirm_your_account())
-        |> put_status(406)
-        |> render(:new, new_bindings)
+        |> respond_with(
+          :session_create_error,
+          %{
+            new_bindings: new_bindings,
+            error: Messages.backend().you_must_confirm_your_account()
+          }
+        )
       end
     else
       conn
       |> track_failed_login(user, user_schema.trackable_table?())
       |> failed_login(user, lockable?)
-      |> put_status(401)
-      |> render(:new, new_bindings)
+      |> respond_with(:session_create_error, %{new_bindings: new_bindings})
     end
   end
 
@@ -113,10 +116,17 @@ defmodule Coherence.SessionController do
 
   defp do_lockable(conn, login_field, _, true) do
     conn
-    |> put_flash(:error, Messages.backend().too_many_failed_login_attempts())
     |> assign(:locked, true)
-    |> put_status(423)
-    |> render("new.html", [{login_field, ""}, remember: rememberable_enabled?()])
+    |> respond_with(
+      :session_create_error_locked,
+      %{
+        params: [
+          {login_field, ""},
+          remember: rememberable_enabled?()
+        ],
+        error: Messages.backend().too_many_failed_login_attempts()
+      }
+    )
   end
 
   defp do_lockable(conn, _login_field, opts, false) do
@@ -132,8 +142,13 @@ defmodule Coherence.SessionController do
     |> reset_failed_attempts(user, lockable?)
     |> track_login(user, user_schema.trackable?(), user_schema.trackable_table?())
     |> save_rememberable(user, remember)
-    |> put_flash(:notice, Messages.backend().signed_in_successfully())
-    |> redirect_to(:session_create, params)
+    |> respond_with(
+      :session_create_success,
+      %{
+        notice: Messages.backend().signed_in_successfully(),
+        params: params
+      }
+    )
   end
 
   @doc """
@@ -145,7 +160,7 @@ defmodule Coherence.SessionController do
   def delete(conn, params) do
     conn
     |> logout_user
-    |> redirect_to(:session_delete, params)
+    |> respond_with(:session_delete_success, %{params: params})
   end
 
   # @doc """
@@ -369,5 +384,4 @@ defmodule Coherence.SessionController do
   defp user_active?(user) do
     Map.get(user, :active, true)
   end
-
 end

--- a/lib/coherence/controllers/unlock_controller.ex
+++ b/lib/coherence/controllers/unlock_controller.ex
@@ -49,25 +49,26 @@ defmodule Coherence.UnlockController do
       case LockableService.unlock_token(user) do
         {:ok, user} ->
           if user_schema.locked?(user) do
-            if Config.mailer?() do
-              send_user_email :unlock, user, router_helpers().unlock_url(conn, :edit, user.unlock_token)
-              put_flash(conn, :info, Messages.backend().unlock_instructions_sent())
-            else
-              put_flash(conn, :error, Messages.backend().mailer_required())
+            conn = case Config.mailer?() do
+              true ->
+                send_user_email :unlock, user, router_helpers().unlock_url(conn, :edit, user.unlock_token)
+                put_flash(conn, :info, Messages.backend().unlock_instructions_sent())
+              _ ->
+                put_flash(conn, :error, Messages.backend().mailer_required())
             end
-            |> redirect_to(:unlock_create, params)
+            conn
+            |> respond_with(:unlock_create_success, %{params: params, user: user})
           else
             conn
-            |> put_flash(:error, Messages.backend().your_account_is_not_locked())
-            |> redirect_to(:unlock_create_not_locked, params)
+            |> respond_with(:unlock_create_error_not_locked, %{params: params, error: Messages.backend().your_account_is_not_locked()})
           end
         {:error, changeset} ->
-          render conn, "new.html", changeset: changeset
+          conn
+          |> respond_with(:unlock_create_error, %{changeset: changeset})
       end
     else
       conn
-      |> put_flash(:error, Messages.backend().invalid_email_or_password())
-      |> redirect_to(:unlock_create_invalid, params)
+      |> respond_with(:unlock_create_error, %{params: params, error: Messages.backend().invalid_email_or_password()})
     end
   end
 
@@ -81,20 +82,17 @@ defmodule Coherence.UnlockController do
     case Schemas.get_by_user unlock_token: token do
       nil ->
         conn
-        |> put_flash(:error, Messages.backend().invalid_unlock_token())
-        |> redirect_to(:unlock_edit_invalid, params)
+        |> respond_with(:unlock_update_error, %{params: params, error: Messages.backend().invalid_unlock_token()})
       user ->
         if user_schema.locked? user do
           Controller.unlock! user
           conn
           |> TrackableService.track_unlock_token(user, user_schema.trackable_table?)
-          |> put_flash(:info, Messages.backend().your_account_has_been_unlocked())
-          |> redirect_to(:unlock_edit, params)
+          |> respond_with(:unlock_update_success, %{params: params, info: Messages.backend().your_account_has_been_unlocked()})
         else
           clear_unlock_values(user, user_schema)
           conn
-          |> put_flash(:error, Messages.backend().account_is_not_locked())
-          |> redirect_to(:unlock_edit_not_locked, params)
+          |> respond_with(:unlock_update_error_not_locked, %{error: Messages.backend().account_is_not_locked()})
         end
     end
   end

--- a/lib/coherence/controllers/unlock_controller.ex
+++ b/lib/coherence/controllers/unlock_controller.ex
@@ -49,26 +49,25 @@ defmodule Coherence.UnlockController do
       case LockableService.unlock_token(user) do
         {:ok, user} ->
           if user_schema.locked?(user) do
-            conn = case Config.mailer?() do
-              true ->
-                send_user_email :unlock, user, router_helpers().unlock_url(conn, :edit, user.unlock_token)
-                put_flash(conn, :info, Messages.backend().unlock_instructions_sent())
-              _ ->
-                put_flash(conn, :error, Messages.backend().mailer_required())
-            end
             conn
+            |> send_unlock_email(user)
             |> respond_with(:unlock_create_success, %{params: params, user: user})
           else
-            conn
-            |> respond_with(:unlock_create_error_not_locked, %{params: params, error: Messages.backend().your_account_is_not_locked()})
+            respond_with(
+              conn,
+              :unlock_create_error_not_locked,
+              %{params: params, error: Messages.backend().your_account_is_not_locked()}
+            )
           end
         {:error, changeset} ->
-          conn
-          |> respond_with(:unlock_create_error, %{changeset: changeset})
+          respond_with(conn,:unlock_create_error, %{changeset: changeset})
       end
     else
-      conn
-      |> respond_with(:unlock_create_error, %{params: params, error: Messages.backend().invalid_email_or_password()})
+      respond_with(
+        conn,
+        :unlock_create_error,
+        %{params: params, error: Messages.backend().invalid_email_or_password()}
+      )
     end
   end
 
@@ -81,8 +80,7 @@ defmodule Coherence.UnlockController do
     token = params["id"]
     case Schemas.get_by_user unlock_token: token do
       nil ->
-        conn
-        |> respond_with(:unlock_update_error, %{params: params, error: Messages.backend().invalid_unlock_token()})
+        respond_with(conn, :unlock_update_error, %{params: params, error: Messages.backend().invalid_unlock_token()})
       user ->
         if user_schema.locked? user do
           Controller.unlock! user
@@ -91,8 +89,11 @@ defmodule Coherence.UnlockController do
           |> respond_with(:unlock_update_success, %{params: params, info: Messages.backend().your_account_has_been_unlocked()})
         else
           clear_unlock_values(user, user_schema)
-          conn
-          |> respond_with(:unlock_update_error_not_locked, %{error: Messages.backend().account_is_not_locked()})
+          respond_with(
+            conn,
+            :unlock_update_error_not_locked,
+            %{error: Messages.backend().account_is_not_locked()}
+          )
         end
     end
   end
@@ -111,6 +112,15 @@ defmodule Coherence.UnlockController do
         _ ->
           :ok
       end
+    end
+  end
+
+  defp send_unlock_email(conn, user) do
+    if Config.mailer?() do
+      send_user_email :unlock, user, router_helpers().unlock_url(conn, :edit, user.unlock_token)
+      put_flash(conn, :info, Messages.backend().unlock_instructions_sent())
+    else
+      put_flash(conn, :error, Messages.backend().mailer_required())
     end
   end
 end

--- a/lib/coherence/plugs/authorization/session.ex
+++ b/lib/coherence/plugs/authorization/session.ex
@@ -232,6 +232,12 @@ defmodule Coherence.Authentication.Session do
   defp verify_auth_key({conn, auth_key}, %{db_model: db_model, id_key: id_key}, store),
     do: {conn, store.get_user_data({auth_key, db_model, id_key})}
 
+  defp assert_login({%{private: %{ phoenix_format: format }} = conn, nil}, login, _opts) when format == "json" and (login == true or is_function(login)) do
+    conn
+    |> send_resp(401, "")
+    |> halt
+  end
+
   defp assert_login({conn, nil}, login, _opts) when login == true or is_function(login) do
     user_return_to =
       case conn.query_string do

--- a/lib/coherence/responders.ex
+++ b/lib/coherence/responders.ex
@@ -1,0 +1,38 @@
+defmodule Responders do
+
+  @callback session_create_success(conn :: term, opts :: term) :: term
+  @callback session_create_error(conn :: term, opts :: term) :: term
+  @callback session_create_error_locked(conn :: term, opts :: term) :: term
+  @callback session_delete_success(conn :: term, opts :: term) :: term
+  @callback session_already_logged_in(conn :: term, opts :: term) :: term
+
+  @callback registration_create_success(conn :: term, opts :: term) :: term
+  @callback registration_create_error(conn :: term, opts :: term) :: term
+  @callback registration_update_success(conn :: term, opts :: term) :: term
+  @callback registration_update_error(conn :: term, opts :: term) :: term
+  @callback registration_delete_success(conn :: term, opts :: term) :: term
+
+  @callback unlock_create_success(conn :: term, opts :: term) :: term
+  @callback unlock_create_error(conn :: term, opts :: term) :: term
+  @callback unlock_create_error_not_locked(conn :: term, opts :: term) :: term
+  @callback unlock_update_success(conn :: term, opts :: term) :: term
+  @callback unlock_update_error(conn :: term, opts :: term) :: term
+  @callback unlock_update_error_not_locked(conn :: term, opts :: term) :: term
+
+  @callback confirmation_create_success(conn :: term, opts :: term) :: term
+  @callback confirmation_create_error(conn :: term, opts :: term) :: term
+  @callback confirmation_update_success(conn :: term, opts :: term) :: term
+  @callback confirmation_update_error(conn :: term, opts :: term) :: term
+
+  @callback password_create_success(conn :: term, opts :: term) :: term
+  @callback password_create_error(conn :: term, opts :: term) :: term
+  @callback password_update_success(conn :: term, opts :: term) :: term
+  @callback password_update_error(conn :: term, opts :: term) :: term
+
+  @callback invitation_create_success(conn :: term, opts :: term) :: term
+  @callback invitation_create_error(conn :: term, opts :: term) :: term
+  @callback invitation_resend_success(conn :: term, opts :: term) :: term
+  @callback invitation_resend_error(conn :: term, opts :: term) :: term
+  @callback invitation_create_user_success(conn :: term, opts :: term) :: term
+  @callback invitation_create_user_error(conn :: term, opts :: term) :: term
+end

--- a/lib/coherence/responders.ex
+++ b/lib/coherence/responders.ex
@@ -1,4 +1,4 @@
-defmodule Responders do
+defmodule Coherence.Responders do
 
   @callback session_create_success(conn :: term, opts :: term) :: term
   @callback session_create_error(conn :: term, opts :: term) :: term

--- a/lib/coherence/responders/html.ex
+++ b/lib/coherence/responders/html.ex
@@ -2,7 +2,7 @@ defmodule Responders.Html do
 
   defmacro __using__(_) do
     quote location: :keep do
-      @behaviour Responders
+      @behaviour Coherence.Responders
 
       import Phoenix.Controller, only: [redirect: 2, put_flash: 3, render: 3]
       import Coherence.Controller

--- a/lib/coherence/responders/html.ex
+++ b/lib/coherence/responders/html.ex
@@ -1,0 +1,298 @@
+defmodule Responders.Html do
+
+  defmacro __using__(_) do
+    quote location: :keep do
+      @behaviour Responders
+
+      import Phoenix.Controller, only: [redirect: 2, put_flash: 3, render: 3]
+      import Coherence.Controller
+      import Plug.Conn, only: [put_status: 2, halt: 1]
+
+      def session_create_error(conn, opts \\ %{})
+      def session_create_error(conn, %{new_bindings: new_bindings, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> put_status(406)
+        |> render(:new, new_bindings)
+      end
+      def session_create_error(conn, %{new_bindings: new_bindings}) do
+        conn
+        |> put_status(401)
+        |> render(:new, new_bindings)
+      end
+
+      def session_create_success(conn, opts \\ %{})
+      def session_create_success(conn, %{notice: notice, params: params}) do
+        conn
+        |> put_flash(:notice, notice)
+        |> redirect_to(:session_create, params)
+      end
+
+      def session_create_error_locked(conn, opts \\ %{})
+      def session_create_error_locked(conn, %{error: error, params: params}) do
+        conn
+        |> put_flash(:error, error)
+        |> put_status(423)
+        |> render(:new, params)
+      end
+
+      def session_delete_success(conn, opts \\ %{})
+      def session_delete_success(conn, %{params: params}) do
+        conn
+        |> redirect_to(:session_delete, params)
+      end
+
+      def session_already_logged_in(conn, opts \\ %{})
+      def session_already_logged_in(conn, %{info: info}) do
+        conn
+        |> put_flash(:info, info)
+        |> redirect(to: logged_in_url(conn))
+        |> halt
+      end
+
+      def registration_create_success(conn, opts \\ %{})
+      def registration_create_success(conn, %{params: params}) do
+        conn
+        |> redirect_to(:session_create, params)
+      end
+
+      def registration_create_error(conn, opts \\ %{})
+      def registration_create_error(conn, %{changeset: changeset}) do
+        conn
+        |> render(:new, changeset: changeset)
+      end
+
+      def registration_update_error(conn, opts \\ %{})
+      def registration_update_error(conn, %{changeset: changeset, user: user}) do
+        conn
+        |> render(:edit, changeset: changeset, user: user)
+      end
+
+      def registration_update_success(conn, opts \\ %{})
+      def registration_update_success(conn, %{params: params, user: user, info: info}) do
+        conn
+        |> put_flash(:info, info)
+        |> redirect_to(:registration_update, params, user)
+      end
+
+      def registration_delete_success(conn, opts \\ %{})
+      def registration_delete_success(conn, %{params: params}) do
+        conn
+        |> redirect_to(:registration_delete, params)
+      end
+
+      def unlock_create_success(conn, opts \\ %{params: %{}, user: nil})
+      def unlock_create_success(conn, %{params: params}) do
+        conn
+        |> redirect_to(:unlock_create, params)
+      end
+
+      def unlock_create_error(conn, opts \\ %{})
+      def unlock_create_error(conn, %{params: params, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect_to(:unlock_create_invalid, params)
+      end
+      def unlock_create_error(conn, %{changeset: changeset}) do
+        render conn, :new, changeset: changeset
+      end
+
+      def unlock_create_error_not_locked(conn, opts \\ %{})
+      def unlock_create_error_not_locked(conn, %{params: params, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect_to(:unlock_create_not_locked, params)
+      end
+
+      def unlock_update_success(conn, opts \\ %{})
+      def unlock_update_success(conn, %{params: params, info: info}) do
+        conn
+        |> put_flash(:info, info)
+        |> redirect_to(:unlock_edit, params)
+      end
+
+      def unlock_update_error(conn, opts \\ %{})
+      def unlock_update_error(conn, %{params: params, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect_to(:unlock_edit_invalid, params)
+      end
+
+      def unlock_update_error_not_locked(conn, opts \\ %{})
+      def unlock_update_error_not_locked(conn, %{params: params, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect_to(:unlock_edit_not_locked, params)
+      end
+
+      def confirmation_create_error(conn, opts \\ %{})
+      def confirmation_create_error(conn, %{changeset: changeset, email: email, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> render(:new, [email: email, changeset: changeset])
+      end
+      def confirmation_create_error(conn, %{changeset: changeset, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> render(:new, changeset: changeset)
+      end
+      def confirmation_create_error(conn, %{changeset: changeset}) do
+        conn
+        |> render(:new, changeset: changeset)
+      end
+
+      def confirmation_create_success(conn, opts \\ %{})
+      def confirmation_create_success(conn, %{params: params}) do
+        conn
+        |> redirect_to(:confirmation_create, params)
+      end
+
+      def confirmation_update_invalid(conn, opts \\ %{})
+      def confirmation_update_invalid(conn, %{params: params, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect_to(:confirmation_edit_invalid, params)
+      end
+
+      def confirmation_update_expired(conn, opts \\ %{})
+      def confirmation_update_expired(conn, %{params: params, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect_to(:confirmation_edit_expired, params)
+      end
+
+      def confirmation_update_error(conn, opts \\ %{})
+      def confirmation_update_error(conn, %{params: params, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect_to(:confirmation_edit_error, params)
+      end
+
+      def confirmation_update_success(conn, opts \\ %{})
+      def confirmation_update_success(conn, %{params: params, info: info}) do
+        conn
+        |> put_flash(:info, info)
+        |> redirect_to(:confirmation_edit, params)
+      end
+
+      def password_create_success(conn, opts \\ %{})
+      def password_create_success(conn, %{params: params, info: info}) do
+        conn
+        |> put_flash(:info, info)
+        |> redirect_to(:password_create, params: params)
+      end
+      def password_create_success(conn, %{params: params, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect_to(:password_create, params: params)
+      end
+
+      def password_create_error(conn, opts \\ %{})
+      def password_create_error(conn, %{changeset: changeset, error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> render(:new, changeset: changeset)
+      end
+
+      def password_update_error(conn, opts \\ %{})
+      def password_update_error(conn, %{error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect(to: logged_out_url(conn))
+      end
+      def password_update_error(conn, %{changeset: changeset}) do
+        conn
+        |> render("edit.html", changeset: changeset)
+      end
+
+      def password_update_success(conn, %{params: params, info: info}) do
+        conn
+        |> put_flash(:info, info)
+        |> redirect_to(:password_update, params)
+      end
+
+      def invitation_create_success(conn, opts \\ %{})
+      def invitation_create_success(conn, %{params: params, info: info}) do
+        conn
+        |> put_flash(:info, info)
+        |> redirect_to(:invitation_create, params)
+      end
+
+      def invitation_create_error(conn, opts \\ %{})
+      def invitation_create_error(conn, %{changeset: changeset}) do
+        conn
+        |> render(:new, changeset: changeset)
+      end
+
+      def invitation_resend_error(conn, opts \\ %{})
+      def invitation_resend_error(conn, %{error: error, params: params}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect_to(:invitation_resend, params)
+      end
+
+      def invitation_resend_success(conn, opts \\ %{})
+      def invitation_resend_success(conn, %{info: info, params: params}) do
+        conn
+        |> put_flash(:info, info)
+        |> redirect_to(:invitation_resend, params)
+      end
+
+      def invitation_create_user_error(conn, opts \\ %{})
+      def invitation_create_user_error(conn, %{error: error}) do
+        conn
+        |> put_flash(:error, error)
+        |> redirect(to: logged_out_url(conn))
+      end
+      def invitation_create_user_error(conn, %{changeset: changeset, token: token}) do
+        conn
+        |> render(:edit, changeset: changeset, token: token)
+      end
+
+      def invitation_create_user_success(conn, opts \\ %{})
+      def invitation_create_user_success(conn, %{}) do
+        conn
+        |> redirect(to: logged_out_url(conn))
+      end
+
+      defoverridable [
+        session_create_success: 2,
+        session_create_error: 2,
+        session_create_error_locked: 2,
+        session_delete_success: 2,
+        session_already_logged_in: 2,
+
+        registration_create_success: 2,
+        registration_create_error: 2,
+        registration_update_success: 2,
+        registration_update_error: 2,
+        registration_delete_success: 2,
+
+        unlock_create_success: 2,
+        unlock_create_error: 2,
+        unlock_create_error_not_locked: 2,
+        unlock_update_success: 2,
+        unlock_update_error: 2,
+        unlock_update_error_not_locked: 2,
+
+        confirmation_create_success: 2,
+        confirmation_create_error: 2,
+        confirmation_update_error: 2,
+        confirmation_update_success: 2,
+
+        password_create_success: 2,
+        password_create_error: 2,
+        password_update_success: 2,
+        password_update_error: 2,
+
+        invitation_create_success: 2,
+        invitation_create_error: 2,
+        invitation_resend_success: 2,
+        invitation_resend_error: 2,
+        invitation_create_user_success: 2,
+        invitation_create_user_error: 2
+      ]
+    end
+  end
+
+end

--- a/lib/coherence/responders/json.ex
+++ b/lib/coherence/responders/json.ex
@@ -1,0 +1,288 @@
+defmodule Responders.Json do
+
+  defmacro __using__(_) do
+    quote location: :keep do
+      @behaviour Responders
+
+      import Phoenix.Controller, only: [render: 2, render: 3, render: 4]
+      import Coherence.Controller
+      import Plug.Conn, only: [put_status: 2, send_resp: 3, halt: 1]
+
+      def session_create_success(conn, opts \\ %{})
+      def session_create_success(conn, _opts) do
+        conn
+        |> put_status(201)
+        |> render(:session, user: conn.assigns.current_user)
+      end
+
+      def session_create_error(conn, opts \\ %{})
+      def session_create_error(conn, %{error: error}) do
+        conn
+        |> put_status(406)
+        |> render(:error, error: error)
+      end
+      def session_create_error(conn, _opts) do
+        conn
+        |> put_status(401)
+        |> render(:error)
+      end
+
+      def session_create_error_locked(conn, opts \\ %{})
+      def session_create_error_locked(conn, %{error: error}) do
+        conn
+        |> put_status(423)
+        |> render(:error, error: error)
+      end
+
+      def session_delete_success(conn, opts \\ %{})
+      def session_delete_success(conn, _) do
+        conn
+        |> send_resp(204, "")
+      end
+
+      def session_already_logged_in(conn, opts \\ %{})
+      def session_already_logged_in(conn, %{info: info}) do
+        conn
+        |> put_status(409)
+        |> render(:error, error: info)
+        |> halt
+      end
+
+      def registration_create_success(conn, opts \\ %{})
+      def registration_create_success(conn, %{user: user}) do
+        conn
+        |> render(:registration, user: user)
+      end
+
+      def registration_create_error(conn, opts \\ %{})
+      def registration_create_error(conn, %{changeset: changeset}) do
+        conn
+        |> put_status(422)
+        |> render(:error, changeset: changeset)
+      end
+
+      def registration_update_error(conn, opts \\ %{})
+      def registration_update_error(conn, %{changeset: changeset}) do
+        conn
+        |> put_status(422)
+        |> render(:error, changeset: changeset)
+      end
+
+      def registration_update_success(conn, opts \\ %{})
+      def registration_update_success(conn, %{user: user, info: info}) do
+        conn
+        |> render(:registration, user: user, info: info)
+      end
+
+      def registration_delete_success(conn, opts \\ %{})
+      def registration_delete_success(conn, %{params: params}) do
+        conn
+        |> send_resp(204, "")
+      end
+
+      def unlock_create_success(conn, %{user: user}) do
+        conn
+        |> put_status(201)
+        |> render(:unlock, user: user)
+      end
+
+      def unlock_create_error(conn, %{error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+      def unlock_create_error(conn, %{changeset: changeset}) do
+        conn
+        |> put_status(422)
+        |> render(:error, changeset: changeset)
+      end
+
+      def unlock_create_error_not_locked(conn, %{error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+
+      def unlock_update_success(conn, opts \\ %{})
+      def unlock_update_success(conn, %{params: _params, info: info}) do
+        conn
+        |> put_status(200)
+        |> render(:unlock, info: info)
+      end
+
+      def unlock_update_error(conn, opts \\ %{})
+      def unlock_update_error(conn, %{params: _params, error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+
+      def unlock_update_error_not_locked(conn, opts \\ %{})
+      def unlock_update_error_not_locked(conn, %{params: _params, error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+
+      def confirmation_create_success(conn, %{params: params}) do
+        conn
+        |> send_resp(201, "")
+      end
+
+      def confirmation_create_error(conn, opts) do
+        conn
+        |> put_status(422)
+        |> render(:error, opts)
+      end
+
+      def confirmation_update_success(conn, opts \\ %{})
+      def confirmation_update_success(conn, %{info: info}) do
+        conn
+        |> put_status(200)
+        |> render(:confirmation, info: info)
+      end
+
+      def confirmation_update_invalid(conn, opts \\ %{})
+      def confirmation_update_invalid(conn, %{error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+
+      def confirmation_update_expired(conn, opts \\ %{})
+      def confirmation_update_expired(conn, %{error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+
+      def confirmation_update_error(conn, opts \\ %{})
+      def confirmation_update_error(conn, %{error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+
+      def password_create_success(conn, opts \\ %{})
+      def password_create_success(conn, %{params: params, info: info}) do
+        conn
+        |> put_status(201)
+        |> render(:password, info: info)
+      end
+      def password_create_success(conn, %{params: params, error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+
+      def password_create_error(conn, opts \\ %{})
+      def password_create_error(conn, %{changeset: changeset, error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, changeset: changeset, error: error)
+      end
+
+      def password_update_error(conn, opts \\ %{})
+      def password_update_error(conn, %{error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+      def password_update_error(conn, %{changeset: changeset}) do
+        conn
+        |> put_status(422)
+        |> render(:error, changeset: changeset)
+      end
+
+      def password_update_success(conn, %{params: params, info: info}) do
+        conn
+        |> render(:password, info: info)
+      end
+
+      def invitation_create_success(conn, opts \\ %{})
+      def invitation_create_success(conn, %{info: info}) do
+        conn
+        |> put_status(201)
+        |> render(:invitation, info: info)
+      end
+
+      def invitation_create_error(conn, opts \\ %{})
+      def invitation_create_error(conn, %{changeset: changeset}) do
+        conn
+        |> put_status(422)
+        |> render(:error, changeset: changeset)
+      end
+
+      def invitation_resend_error(conn, opts \\ %{})
+      def invitation_resend_error(conn, %{error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+
+      def invitation_resend_success(conn, opts \\ %{})
+      def invitation_resend_success(conn, %{info: info}) do
+        conn
+        |> put_status(200)
+        |> render(:invitation, info: info)
+      end
+
+      def invitation_create_user_error(conn, opts \\ %{})
+      def invitation_create_user_error(conn, %{error: error}) do
+        conn
+        |> put_status(422)
+        |> render(:error, error: error)
+      end
+      def invitation_create_user_error(conn, %{changeset: changeset}) do
+        conn
+        |> put_status(422)
+        |> render(:error, changeset: changeset)
+      end
+
+      def invitation_create_user_success(conn, opts \\ %{})
+      def invitation_create_user_success(conn, %{}) do
+        conn
+        |> send_resp(201, "")
+      end
+
+      defoverridable [
+        session_create_success: 2,
+        session_create_error: 2,
+        session_create_error_locked: 2,
+        session_delete_success: 2,
+        session_already_logged_in: 2,
+
+        registration_create_success: 2,
+        registration_create_error: 2,
+        registration_update_success: 2,
+        registration_update_error: 2,
+        registration_delete_success: 2,
+
+        unlock_create_success: 2,
+        unlock_create_error: 2,
+        unlock_create_error_not_locked: 2,
+        unlock_update_success: 2,
+        unlock_update_error: 2,
+        unlock_update_error_not_locked: 2,
+
+        confirmation_create_success: 2,
+        confirmation_create_error: 2,
+        confirmation_update_error: 2,
+        confirmation_update_success: 2,
+
+        password_create_success: 2,
+        password_create_error: 2,
+        password_update_success: 2,
+        password_update_error: 2,
+
+        invitation_create_success: 2,
+        invitation_create_error: 2,
+        invitation_resend_success: 2,
+        invitation_resend_error: 2,
+        invitation_create_user_success: 2,
+        invitation_create_user_error: 2
+      ]
+    end
+  end
+
+end

--- a/lib/coherence/responders/json.ex
+++ b/lib/coherence/responders/json.ex
@@ -2,7 +2,7 @@ defmodule Responders.Json do
 
   defmacro __using__(_) do
     quote location: :keep do
-      @behaviour Responders
+      @behaviour Coherence.Responders
 
       import Phoenix.Controller, only: [render: 2, render: 3, render: 4]
       import Coherence.Controller

--- a/lib/mix/tasks/coh.install.ex
+++ b/lib/mix/tasks/coh.install.ex
@@ -222,6 +222,7 @@ defmodule Mix.Tasks.Coh.Install do
     |> gen_coherence_templates
     |> gen_coherence_mailer
     |> gen_redirects
+    |> gen_responders
     |> touch_config                # work around for config file not getting recompiled
     |> print_instructions
   end
@@ -707,6 +708,17 @@ defmodule Mix.Tasks.Coh.Install do
   end
 
   defp gen_redirects(config), do: config
+
+  defp gen_responders(%{boilerplate: true, binding: binding, web_path: web_path} = config) do
+    copy_from paths(),
+      "priv/templates/coh.install/controllers/coherence/responders", "", binding, [
+        {:eex, "html.ex", Path.join(web_path, "controllers/coherence/responders/html.ex")},
+        {:eex, "json.ex", Path.join(web_path, "controllers/coherence/responders/json.ex")},
+      ], config
+    config
+  end
+
+  defp gen_responders(config), do: config
 
   ################
   # Views

--- a/priv/templates/coh.gen.controllers/controllers/coherence/confirmation_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/confirmation_controller.ex
@@ -10,7 +10,7 @@ defmodule <%= web_base %>.Coherence.ConfirmationController do
 
   alias Coherence.{ConfirmableService, Messages}
   alias Ecto.DateTime
-  alias <%= base %>.Coherence.Schemas
+  alias Coherence.Schemas
 
   require Logger
 
@@ -45,17 +45,28 @@ defmodule <%= web_base %>.Coherence.ConfirmationController do
     case user do
       nil ->
         conn
-        |> put_flash(:error, Messages.backend().could_not_find_that_email_address())
-        |> render("new.html", changeset: changeset)
+        |> respond_with(
+          :confirmation_create_error,
+          %{
+            changeset: changeset,
+            error: Messages.backend().could_not_find_that_email_address()
+          }
+        )
       user ->
         if user_schema.confirmed?(user) do
           conn
-          |> put_flash(:error, Messages.backend().account_already_confirmed())
-          |> render(:new, [email: "", changeset: changeset])
+          |> respond_with(
+            :confirmation_create_error,
+            %{
+              changeset: changeset,
+              email: "",
+              error: Messages.backend().account_already_confirmed()
+            }
+          )
         else
           conn
           |> send_confirmation(user, user_schema)
-          |> redirect_to(:confirmation_create, params)
+          |> respond_with(:confirmation_create_success, %{params: params})
         end
     end
   end
@@ -77,27 +88,47 @@ defmodule <%= web_base %>.Coherence.ConfirmationController do
       nil ->
         changeset = Controller.changeset :confirmation, user_schema, user_schema.__struct__
         conn
-        |> put_flash(:error, Messages.backend().invalid_confirmation_token())
-        |> redirect_to(:confirmation_edit_invalid, params)
+        |> respond_with(
+          :confirmation_update_invalid,
+          %{
+            params: params,
+            error: Messages.backend().invalid_confirmation_token()
+          }
+        )
       user ->
         if ConfirmableService.expired? user do
           conn
-          |> put_flash(:error, Messages.backend().confirmation_token_expired())
-          |> redirect_to(:confirmation_edit_expired, params)
+          |> respond_with(
+            :confirmation_update_expired,
+            %{
+              params: params,
+              error: Messages.backend().confirmation_token_expired()
+            }
+          )
         else
           changeset = Controller.changeset(:confirmation, user_schema, user, %{
             confirmation_token: nil,
             confirmed_at: DateTime.utc,
-            })
+          })
           case Config.repo.update(changeset) do
             {:ok, _user} ->
               conn
-              |> put_flash(:info, Messages.backend().user_account_confirmed_successfully())
-              |> redirect_to(:confirmation_edit, params)
+              |> respond_with(
+                :confirmation_update_success,
+                %{
+                  params: params,
+                  info: Messages.backend().user_account_confirmed_successfully()
+                }
+              )
             {:error, _changeset} ->
               conn
-              |> put_flash(:error, Messages.backend().problem_confirming_user_account())
-              |> redirect_to(:confirmation_edit_error, params)
+              |> respond_with(
+                :confirmation_update_error,
+                %{
+                  params: params,
+                  error: Messages.backend().problem_confirming_user_account()
+                }
+              )
           end
         end
     end

--- a/priv/templates/coh.gen.controllers/controllers/coherence/invitation_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/invitation_controller.ex
@@ -124,16 +124,15 @@ defmodule <%= web_base %>.Coherence.InvitationController do
     user_schema = Config.user_schema
     case Schemas.get_by_invitation token: token do
       nil ->
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :invitation_create_user_error,
           %{
             error: Messages.backend().invalid_invitation()
           }
         )
       invite ->
-        :invitation
-        |> Controller.changeset(user_schema, user_schema.__struct__, params["user"])
+        Controller.changeset(:invitation, user_schema, user_schema.__struct__, params["user"])
         |> Schemas.create
         |> case do
           {:ok, user} ->
@@ -144,8 +143,8 @@ defmodule <%= web_base %>.Coherence.InvitationController do
               :invitation_create_user_success
             )
           {:error, changeset} ->
-            conn
-            |> respond_with(
+            respond_with(
+              conn,
               :invitation_create_user_error,
               %{
                 changeset: changeset,
@@ -165,8 +164,8 @@ defmodule <%= web_base %>.Coherence.InvitationController do
   def resend(conn, %{"id" => id} = params) do
     case Schemas.get_invitation id do
       nil ->
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :invitation_resend_error,
           %{
             params: params,
@@ -176,8 +175,8 @@ defmodule <%= web_base %>.Coherence.InvitationController do
       invitation ->
         send_user_email :invitation, invitation,
           router_helpers().invitation_url(conn, :edit, invitation.token)
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :invitation_resend_success,
           %{
             params: params,

--- a/priv/templates/coh.gen.controllers/controllers/coherence/invitation_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/invitation_controller.ex
@@ -59,7 +59,8 @@ defmodule <%= web_base %>.Coherence.InvitationController do
           changeset
           |> add_error(:email, Messages.backend().user_already_has_an_account())
           |> struct(action: true)
-        render(conn, "new.html", changeset: changeset)
+        conn
+        |> respond_with(:invitation_create_error, %{changeset: changeset})
     end
   end
 
@@ -68,8 +69,13 @@ defmodule <%= web_base %>.Coherence.InvitationController do
       {:ok, invitation} ->
         send_user_email :invitation, invitation, url
         conn
-        |> put_flash(:info, Messages.backend().invitation_sent())
-        |> redirect_to(:invitation_create, params)
+        |> respond_with(
+          :invitation_create_success,
+          %{
+            params: params,
+            info: Messages.backend().invitation_sent()
+          }
+        )
       {:error, changeset} ->
         {conn, changeset} =
           case Schemas.get_by_invitation email: email do
@@ -79,7 +85,8 @@ defmodule <%= web_base %>.Coherence.InvitationController do
                 add_error(changeset, :email,
                   Messages.backend().invitation_already_sent())}
           end
-        render(conn, "new.html", changeset: changeset)
+        conn
+        |> respond_with(:invitation_create_error, %{changeset: changeset})
     end
   end
 
@@ -118,8 +125,12 @@ defmodule <%= web_base %>.Coherence.InvitationController do
     case Schemas.get_by_invitation token: token do
       nil ->
         conn
-        |> put_flash(:error, Messages.backend().invalid_invitation())
-        |> redirect(to: logged_out_url(conn))
+        |> respond_with(
+          :invitation_create_user_error,
+          %{
+            error: Messages.backend().invalid_invitation()
+          }
+        )
       invite ->
         :invitation
         |> Controller.changeset(user_schema, user_schema.__struct__, params["user"])
@@ -129,9 +140,18 @@ defmodule <%= web_base %>.Coherence.InvitationController do
             Schemas.delete invite
             conn
             |> send_confirmation(user, user_schema)
-            |> redirect(to: logged_out_url(conn))
+            |> respond_with(
+              :invitation_create_user_success
+            )
           {:error, changeset} ->
-            render conn, "edit.html", changeset: changeset, token: token
+            conn
+            |> respond_with(
+              :invitation_create_user_error,
+              %{
+                changeset: changeset,
+                token: token
+              }
+            )
         end
     end
   end
@@ -143,15 +163,27 @@ defmodule <%= web_base %>.Coherence.InvitationController do
   """
   @spec resend(conn, params) :: conn
   def resend(conn, %{"id" => id} = params) do
-    conn =
-      case Schemas.get_invitation id do
-        nil ->
-          put_flash(conn, :error, Messages.backend().cant_find_that_token())
-        invitation ->
-          send_user_email :invitation, invitation,
-            router_helpers().invitation_url(conn, :edit, invitation.token)
-          put_flash conn, :info, Messages.backend().invitation_sent()
-      end
-    redirect_to(conn, :invitation_resend, params)
+    case Schemas.get_invitation id do
+      nil ->
+        conn
+        |> respond_with(
+          :invitation_resend_error,
+          %{
+            params: params,
+            error: Messages.backend().cant_find_that_token()
+          }
+        )
+      invitation ->
+        send_user_email :invitation, invitation,
+          router_helpers().invitation_url(conn, :edit, invitation.token)
+        conn
+        |> respond_with(
+          :invitation_resend_success,
+          %{
+            params: params,
+            info: Messages.backend().invitation_sent()
+          }
+        )
+    end
   end
 end

--- a/priv/templates/coh.gen.controllers/controllers/coherence/password_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/password_controller.ex
@@ -47,8 +47,13 @@ defmodule <%= web_base %>.Coherence.PasswordController do
       nil ->
         changeset = Controller.changeset :password, user_schema, user_schema.__struct__
         conn
-        |> put_flash(:error, Messages.backend().could_not_find_that_email_address())
-        |> render("new.html", changeset: changeset)
+        |> respond_with(
+          :password_create_error,
+          %{
+            changeset: changeset,
+            error: Messages.backend().could_not_find_that_email_address()
+          }
+        )
       user ->
         token = random_string 48
         url = router_helpers().password_url(conn, :edit, token)
@@ -59,11 +64,24 @@ defmodule <%= web_base %>.Coherence.PasswordController do
 
         if Config.mailer?() do
           send_user_email :password, user, url
-          put_flash(conn, :info, Messages.backend().reset_email_sent())
+          conn
+          |> respond_with(
+            :password_create_success,
+            %{
+              params: params,
+              info: Messages.backend().reset_email_sent()
+            }
+          )
         else
-          put_flash(conn, :error, Messages.backend().mailer_required())
+          conn
+          |> respond_with(
+            :password_create_success,
+            %{
+              params: params,
+              error: Messages.backend().mailer_required()
+            }
+          )
         end
-        |> redirect_to(:password_create, params)
     end
   end
 
@@ -107,8 +125,10 @@ defmodule <%= web_base %>.Coherence.PasswordController do
     case Schemas.get_by_user reset_password_token: token do
       nil ->
         conn
-        |> put_flash(:error, Messages.backend().invalid_reset_token())
-        |> redirect(to: logged_out_url(conn))
+        |> respond_with(
+          :password_update_error,
+          %{error: Messages.backend().invalid_reset_token()}
+        )
       user ->
         if expired? user.reset_password_sent_at, days: Config.reset_token_expire_days do
           :password
@@ -116,8 +136,10 @@ defmodule <%= web_base %>.Coherence.PasswordController do
           |> Schemas.update
 
           conn
-          |> put_flash(:error, Messages.backend().password_reset_token_expired())
-          |> redirect(to: logged_out_url(conn))
+          |> respond_with(
+            :password_update_error,
+            %{error: Messages.backend().password_reset_token_expired()}
+          )
         else
           params = clear_password_params password_params
 
@@ -128,10 +150,19 @@ defmodule <%= web_base %>.Coherence.PasswordController do
             {:ok, user} ->
               conn
               |> TrackableService.track_password_reset(user, user_schema.trackable_table?)
-              |> put_flash(:info, Messages.backend().password_updated_successfully())
-              |> redirect_to(:password_update, params)
+              |> respond_with(
+                :password_update_success,
+                %{
+                  params: params,
+                  info: Messages.backend().password_updated_successfully()
+                }
+              )
             {:error, changeset} ->
-              render(conn, "edit.html", changeset: changeset)
+              conn
+              |> respond_with(
+                :password_update_error,
+                %{changeset: changeset}
+              )
           end
         end
     end

--- a/priv/templates/coh.gen.controllers/controllers/coherence/password_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/password_controller.ex
@@ -46,8 +46,8 @@ defmodule <%= web_base %>.Coherence.PasswordController do
     case Schemas.get_user_by_email password_params["email"] do
       nil ->
         changeset = Controller.changeset :password, user_schema, user_schema.__struct__
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :password_create_error,
           %{
             changeset: changeset,
@@ -64,8 +64,8 @@ defmodule <%= web_base %>.Coherence.PasswordController do
 
         if Config.mailer?() do
           send_user_email :password, user, url
-          conn
-          |> respond_with(
+          respond_with(
+            conn,
             :password_create_success,
             %{
               params: params,
@@ -73,8 +73,8 @@ defmodule <%= web_base %>.Coherence.PasswordController do
             }
           )
         else
-          conn
-          |> respond_with(
+          respond_with(
+            conn,
             :password_create_success,
             %{
               params: params,
@@ -124,8 +124,8 @@ defmodule <%= web_base %>.Coherence.PasswordController do
 
     case Schemas.get_by_user reset_password_token: token do
       nil ->
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :password_update_error,
           %{error: Messages.backend().invalid_reset_token()}
         )
@@ -135,8 +135,8 @@ defmodule <%= web_base %>.Coherence.PasswordController do
           |> Controller.changeset(user_schema, user, clear_password_params())
           |> Schemas.update
 
-          conn
-          |> respond_with(
+          respond_with(
+            conn,
             :password_update_error,
             %{error: Messages.backend().password_reset_token_expired()}
           )
@@ -158,8 +158,8 @@ defmodule <%= web_base %>.Coherence.PasswordController do
                 }
               )
             {:error, changeset} ->
-              conn
-              |> respond_with(
+              respond_with(
+                conn,
                 :password_update_error,
                 %{changeset: changeset}
               )

--- a/priv/templates/coh.gen.controllers/controllers/coherence/registration_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/registration_controller.ex
@@ -60,14 +60,12 @@ defmodule <%= web_base %>.Coherence.RegistrationController do
         |> send_confirmation(user, user_schema)
         |> redirect_or_login(user, params, Config.allow_unconfirmed_access_for)
       {:error, changeset} ->
-        conn
-        |> respond_with(:registration_create_error, %{changeset: changeset})
+        respond_with(conn, :registration_create_error, %{changeset: changeset})
     end
   end
 
   defp redirect_or_login(conn, user, params, 0) do
-    conn
-    |> respond_with(:registration_create_success, %{params: params, user: user})
+    respond_with(conn, :registration_create_success, %{params: params, user: user})
   end
   defp redirect_or_login(conn, user, params, _) do
     conn
@@ -117,8 +115,7 @@ defmodule <%= web_base %>.Coherence.RegistrationController do
           }
         )
       {:error, changeset} ->
-        conn
-        |> respond_with(:registration_update_error, %{user: user, changeset: changeset})
+        respond_with(conn, :registration_update_error, %{user: user, changeset: changeset})
     end
   end
 

--- a/priv/templates/coh.gen.controllers/controllers/coherence/registration_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/registration_controller.ex
@@ -60,17 +60,19 @@ defmodule <%= web_base %>.Coherence.RegistrationController do
         |> send_confirmation(user, user_schema)
         |> redirect_or_login(user, params, Config.allow_unconfirmed_access_for)
       {:error, changeset} ->
-        render(conn, "new.html", changeset: changeset)
+        conn
+        |> respond_with(:registration_create_error, %{changeset: changeset})
     end
   end
 
-  defp redirect_or_login(conn, _user, params, 0) do
-    redirect_to(conn, :registration_create, params)
+  defp redirect_or_login(conn, user, params, 0) do
+    conn
+    |> respond_with(:registration_create_success, %{params: params, user: user})
   end
   defp redirect_or_login(conn, user, params, _) do
     conn
     |> Controller.login_user(user, params)
-    |> redirect_to(:session_create, params)
+    |> respond_with(:session_create_success, %{params: params, user: user})
   end
 
   @doc """
@@ -106,10 +108,17 @@ defmodule <%= web_base %>.Coherence.RegistrationController do
       {:ok, user} ->
         Config.auth_module
         |> apply(Config.update_login, [conn, user, [id_key: Config.schema_key]])
-        |> put_flash(:info, Messages.backend().account_updated_successfully())
-        |> redirect_to(:registration_update, params, user)
+        |> respond_with(
+          :registration_update_success,
+          %{
+            user: user,
+            params: params,
+            info: Messages.backend().account_updated_successfully()
+          }
+        )
       {:error, changeset} ->
-        render(conn, "edit.html", user: user, changeset: changeset)
+        conn
+        |> respond_with(:registration_update_error, %{user: user, changeset: changeset})
     end
   end
 
@@ -121,6 +130,6 @@ defmodule <%= web_base %>.Coherence.RegistrationController do
     user = Coherence.current_user(conn)
     conn = Controller.logout_user(conn)
     Schemas.delete! user
-    redirect_to(conn, :registration_delete, params)
+    respond_with(conn, :registration_delete_success, %{params: params})
   end
 end

--- a/priv/templates/coh.gen.controllers/controllers/coherence/session_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/session_controller.ex
@@ -87,16 +87,19 @@ defmodule <%= web_base %>.Coherence.SessionController do
           user_schema.lockable?() and user_schema.locked?(user))
       else
         conn
-        |> put_flash(:error, Messages.backend().you_must_confirm_your_account())
-        |> put_status(406)
-        |> render(:new, new_bindings)
+        |> respond_with(
+          :session_create_error,
+          %{
+            new_bindings: new_bindings,
+            error: Messages.backend().you_must_confirm_your_account()
+          }
+        )
       end
     else
       conn
       |> track_failed_login(user, user_schema.trackable_table?())
       |> failed_login(user, lockable?)
-      |> put_status(401)
-      |> render(:new, new_bindings)
+      |> respond_with(:session_create_error, %{new_bindings: new_bindings})
     end
   end
 
@@ -113,10 +116,17 @@ defmodule <%= web_base %>.Coherence.SessionController do
 
   defp do_lockable(conn, login_field, _, true) do
     conn
-    |> put_flash(:error, Messages.backend().too_many_failed_login_attempts())
     |> assign(:locked, true)
-    |> put_status(423)
-    |> render("new.html", [{login_field, ""}, remember: rememberable_enabled?()])
+    |> respond_with(
+      :session_create_error_locked,
+      %{
+        params: [
+          {login_field, ""},
+          remember: rememberable_enabled?()
+        ],
+        error: Messages.backend().too_many_failed_login_attempts()
+      }
+    )
   end
 
   defp do_lockable(conn, _login_field, opts, false) do
@@ -132,8 +142,13 @@ defmodule <%= web_base %>.Coherence.SessionController do
     |> reset_failed_attempts(user, lockable?)
     |> track_login(user, user_schema.trackable?(), user_schema.trackable_table?())
     |> save_rememberable(user, remember)
-    |> put_flash(:notice, Messages.backend().signed_in_successfully())
-    |> redirect_to(:session_create, params)
+    |> respond_with(
+      :session_create_success,
+      %{
+        notice: Messages.backend().signed_in_successfully(),
+        params: params
+      }
+    )
   end
 
   @doc """
@@ -145,7 +160,7 @@ defmodule <%= web_base %>.Coherence.SessionController do
   def delete(conn, params) do
     conn
     |> logout_user
-    |> redirect_to(:session_delete, params)
+    |> respond_with(:session_delete_success, %{params: params})
   end
 
   # @doc """
@@ -369,5 +384,4 @@ defmodule <%= web_base %>.Coherence.SessionController do
   defp user_active?(user) do
     Map.get(user, :active, true)
   end
-
 end

--- a/priv/templates/coh.gen.controllers/controllers/coherence/session_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/session_controller.ex
@@ -86,8 +86,8 @@ defmodule <%= web_base %>.Coherence.SessionController do
         do_lockable(conn, login_field, [user, user_schema, remember, lockable?, remember, params],
           user_schema.lockable?() and user_schema.locked?(user))
       else
-        conn
-        |> respond_with(
+        respond_with(
+          conn,
           :session_create_error,
           %{
             new_bindings: new_bindings,

--- a/priv/templates/coh.install/controllers/coherence/responders/html.ex
+++ b/priv/templates/coh.install/controllers/coherence/responders/html.ex
@@ -1,0 +1,3 @@
+defmodule Coherence.Responders.Html do
+  use Responders.Html
+end

--- a/priv/templates/coh.install/controllers/coherence/responders/json.ex
+++ b/priv/templates/coh.install/controllers/coherence/responders/json.ex
@@ -1,0 +1,3 @@
+defmodule Coherence.Responders.Json do
+  use Responders.Json
+end

--- a/priv/templates/coh.install/views/coherence/coherence_view_helpers.ex
+++ b/priv/templates/coh.install/views/coherence/coherence_view_helpers.ex
@@ -207,4 +207,37 @@ defmodule <%= web_base %>.Coherence.ViewHelpers do
       current_user.name
     end
   end
+
+  @doc """
+  Translates an error message using gettext.
+  """
+  def translate_error({msg, opts}) do
+    # Because error messages were defined within Ecto, we must
+    # call the Gettext module passing our Gettext backend. We
+    # also use the "errors" domain as translations are placed
+    # in the errors.po file.
+    # Ecto will pass the :count keyword if the error message is
+    # meant to be pluralized.
+    # On your own code and templates, depending on whether you
+    # need the message to be pluralized or not, this could be
+    # written simply as:
+    #
+    #     dngettext "errors", "1 file", "%{count} files", count
+    #     dgettext "errors", "is invalid"
+    #
+    if count = opts[:count] do
+      Gettext.dngettext(<%= web_base %>.Gettext, "errors", msg, msg, count, opts)
+    else
+      Gettext.dgettext(<%= web_base %>.Gettext, "errors", msg, opts)
+    end
+  end
+
+  @doc """
+  TODO: doc.
+  """
+  def error_string_from_changeset(changeset) do
+    Enum.map(changeset.errors, fn {k, v} ->
+      "#{Phoenix.Naming.humanize(k)} #{translate_error(v)}"
+    end) |> Enum.join(". ")
+  end
 end

--- a/priv/templates/coh.install/views/coherence/coherence_view_helpers.ex
+++ b/priv/templates/coh.install/views/coherence/coherence_view_helpers.ex
@@ -233,7 +233,7 @@ defmodule <%= web_base %>.Coherence.ViewHelpers do
   end
 
   @doc """
-  TODO: doc.
+  Generates an error string from changeset errors.
   """
   def error_string_from_changeset(changeset) do
     Enum.map(changeset.errors, fn {k, v} ->

--- a/priv/templates/coh.install/views/coherence/confirmation_view.ex
+++ b/priv/templates/coh.install/views/coherence/confirmation_view.ex
@@ -1,3 +1,22 @@
 defmodule <%= web_base %>.Coherence.ConfirmationView do
   use <%= web_module %>, :view
+
+  def render("confirmation.json", %{info: info}) do
+    %{
+      info: info
+    }
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    changeset = cond do
+      is_nil(changeset) || changeset == "" -> "Unknown error."
+      is_bitstring(changeset) -> changeset
+      true -> error_string_from_changeset(changeset)
+    end
+
+    %{error: changeset}
+  end
+  def render("error.json", %{error: error}) do
+    %{error: error}
+  end
 end

--- a/priv/templates/coh.install/views/coherence/invitation_view.ex
+++ b/priv/templates/coh.install/views/coherence/invitation_view.ex
@@ -6,11 +6,12 @@ defmodule <%= web_base %>.Coherence.InvitationView do
   end
 
   def render("error.json", %{changeset: changeset}) do
-    changeset = cond do
-      is_nil(changeset) || changeset == "" -> "Unknown error."
-      is_bitstring(changeset) -> changeset
-      true -> error_string_from_changeset(changeset)
-    end
+    changeset =
+      cond do
+        is_nil(changeset) || changeset == "" -> "Unknown error."
+        is_bitstring(changeset) -> changeset
+        true -> error_string_from_changeset(changeset)
+      end
 
     %{error: changeset}
   end

--- a/priv/templates/coh.install/views/coherence/invitation_view.ex
+++ b/priv/templates/coh.install/views/coherence/invitation_view.ex
@@ -1,3 +1,20 @@
 defmodule <%= web_base %>.Coherence.InvitationView do
   use <%= web_module %>, :view
+
+  def render("invitation.json", %{info: info}) do
+    %{info: info}
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    changeset = cond do
+      is_nil(changeset) || changeset == "" -> "Unknown error."
+      is_bitstring(changeset) -> changeset
+      true -> error_string_from_changeset(changeset)
+    end
+
+    %{error: changeset}
+  end
+  def render("error.json", %{error: error}) do
+    %{error: error}
+  end
 end

--- a/priv/templates/coh.install/views/coherence/password_view.ex
+++ b/priv/templates/coh.install/views/coherence/password_view.ex
@@ -12,11 +12,12 @@ defmodule <%= web_base %>.Coherence.PasswordView do
     %{error: error}
   end
   def render("error.json", %{changeset: changeset}) do
-    changeset = cond do
-      is_nil(changeset) || changeset == "" -> "Unknown error."
-      is_bitstring(changeset) -> changeset
-      true -> error_string_from_changeset(changeset)
-    end
+    changeset =
+      cond do
+        is_nil(changeset) || changeset == "" -> "Unknown error."
+        is_bitstring(changeset) -> changeset
+        true -> error_string_from_changeset(changeset)
+      end
 
     %{error: changeset}
   end

--- a/priv/templates/coh.install/views/coherence/password_view.ex
+++ b/priv/templates/coh.install/views/coherence/password_view.ex
@@ -1,3 +1,23 @@
 defmodule <%= web_base %>.Coherence.PasswordView do
   use <%= web_module %>, :view
+
+  def render("password.json", %{info: info}) do
+    %{info: info}
+  end
+  def render("password.json", %{error: error}) do
+    %{error: error}
+  end
+
+  def render("error.json", %{error: error}) do
+    %{error: error}
+  end
+  def render("error.json", %{changeset: changeset}) do
+    changeset = cond do
+      is_nil(changeset) || changeset == "" -> "Unknown error."
+      is_bitstring(changeset) -> changeset
+      true -> error_string_from_changeset(changeset)
+    end
+
+    %{error: changeset}
+  end
 end

--- a/priv/templates/coh.install/views/coherence/registration_view.ex
+++ b/priv/templates/coh.install/views/coherence/registration_view.ex
@@ -1,3 +1,32 @@
 defmodule <%= web_base %>.Coherence.RegistrationView do
   use <%= web_module %>, :view
+
+  def render("registration.json", %{user: user}) do
+    %{
+      user: %{
+        id: user.id,
+        name: user.name,
+        email: user.email
+      }
+    }
+  end
+
+  def render("session.json", %{user: user}) do
+    %{
+      user: %{
+        id: user.id,
+        name: user.name,
+        email: user.email
+      }
+    }
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    changeset = cond do
+      is_nil(changeset) || changeset == "" -> "Unknown error."
+      is_bitstring(changeset) -> changeset
+      true -> error_string_from_changeset(changeset)
+    end
+    %{error: changeset}
+  end
 end

--- a/priv/templates/coh.install/views/coherence/registration_view.ex
+++ b/priv/templates/coh.install/views/coherence/registration_view.ex
@@ -22,11 +22,12 @@ defmodule <%= web_base %>.Coherence.RegistrationView do
   end
 
   def render("error.json", %{changeset: changeset}) do
-    changeset = cond do
-      is_nil(changeset) || changeset == "" -> "Unknown error."
-      is_bitstring(changeset) -> changeset
-      true -> error_string_from_changeset(changeset)
-    end
+    changeset =
+      cond do
+        is_nil(changeset) || changeset == "" -> "Unknown error."
+        is_bitstring(changeset) -> changeset
+        true -> error_string_from_changeset(changeset)
+      end
     %{error: changeset}
   end
 end

--- a/priv/templates/coh.install/views/coherence/session_view.ex
+++ b/priv/templates/coh.install/views/coherence/session_view.ex
@@ -1,3 +1,24 @@
 defmodule <%= web_base %>.Coherence.SessionView do
   use <%= web_module %>, :view
+
+  def render("session.json", %{user: user}) do
+    %{
+      user: %{
+        id: user.id,
+        name: user.name,
+        email: user.email
+      }
+    }
+  end
+
+  def render("error.json", %{error: error}) do
+    %{
+      error: error
+    }
+  end
+  def render("error.json", _opts) do
+    %{
+      error: "Invalid credentials"
+    }
+  end
 end

--- a/priv/templates/coh.install/views/coherence/unlock_view.ex
+++ b/priv/templates/coh.install/views/coherence/unlock_view.ex
@@ -1,3 +1,33 @@
 defmodule <%= web_base %>.Coherence.UnlockView do
   use <%= web_module %>, :view
+
+  def render("unlock.json", %{info: info}) do
+    %{
+      info: info
+    }
+  end
+  def render("unlock.json", %{user: user}) do
+    %{
+      user: %{
+        id: user.id,
+        name: user.name,
+        email: user.email
+      }
+    }
+  end
+
+  def render("error.json", %{error: error}) do
+    %{
+      error: error
+    }
+  end
+  def render("error.json", %{changeset: changeset}) do
+    changeset = cond do
+      is_nil(changeset) || changeset == "" -> "Unknown error."
+      is_bitstring(changeset) -> changeset
+      true -> error_string_from_changeset(changeset)
+    end
+
+    %{error: changeset}
+  end
 end

--- a/priv/templates/coh.install/views/coherence/unlock_view.ex
+++ b/priv/templates/coh.install/views/coherence/unlock_view.ex
@@ -22,11 +22,12 @@ defmodule <%= web_base %>.Coherence.UnlockView do
     }
   end
   def render("error.json", %{changeset: changeset}) do
-    changeset = cond do
-      is_nil(changeset) || changeset == "" -> "Unknown error."
-      is_bitstring(changeset) -> changeset
-      true -> error_string_from_changeset(changeset)
-    end
+    changeset =
+      cond do
+        is_nil(changeset) || changeset == "" -> "Unknown error."
+        is_bitstring(changeset) -> changeset
+        true -> error_string_from_changeset(changeset)
+      end
 
     %{error: changeset}
   end

--- a/test/mix/tasks/coh.install_test.exs
+++ b/test/mix/tasks/coh.install_test.exs
@@ -126,6 +126,14 @@ defmodule Mix.Tasks.Coh.InstallTest do
       assert_file web_path("controllers/coherence/redirects.ex"), fn file ->
         assert file =~ "import TestCoherenceWeb.Router.Helpers"
       end
+
+      assert_file web_path("controllers/coherence/responders/html.ex"), fn file ->
+        assert file =~ "use Responders.Html"
+      end
+
+      assert_file web_path("controllers/coherence/responders/json.ex"), fn file ->
+        assert file =~ "use Responders.Json"
+      end
     end
   end
 

--- a/test/support/responders/html.ex
+++ b/test/support/responders/html.ex
@@ -1,0 +1,3 @@
+defmodule Coherence.Responders.Html do
+  use Responders.Html
+end

--- a/test/support/responders/json.ex
+++ b/test/support/responders/json.ex
@@ -1,0 +1,3 @@
+defmodule Coherence.Responders.Json do
+  use Responders.Json
+end


### PR DESCRIPTION
As I need to deal with coherence API in a Single Page Application, I added a Responders behavior to easily handle requests in non-html format.

This behavior also allow to override API responses for a given format (html and json for now).

I created an example app to demonstrate how it can be integrated with a react SPA: https://github.com/klacointe/coherence_spa_example 

related: #21, #173, #290