### PR TITLE
Use Ecto :utc_datetime fields instead of Ecto.DateTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,8 +357,8 @@ Adds the following database field to your User model with the generated migratio
 
 ```elixir
 add :sign_in_count, :integer, default: 0  # how many times the user has logged in
-add :current_sign_in_at, :datetime        # the current login timestamp
-add :last_sign_in_at, :datetime           # the timestamp of the previous login
+add :current_sign_in_at, :utc_datetime    # the current login timestamp
+add :last_sign_in_at, :utc_datetime       # the timestamp of the previous login
 add :current_sign_in_ip, :string          # the current login IP adddress
 add :last_sign_in_ip, :string             # the IP address of the previous login
 ```
@@ -377,7 +377,7 @@ Adds the following database field to your User model with the generated migratio
 ```elixir
 add :failed_attempts, :integer, default: 0
 add :unlock_token, :string
-add :locked_at, :datetime
+add :locked_at, :utc_datetime
 ```
 
 ### Unlockable with Token
@@ -405,7 +405,7 @@ The following table is created by the generated `<timestamp>_create_coherence_re
 create table(:rememberables) do
   add :series_hash, :string
   add :token_hash, :string
-  add :token_created_at, :datetime
+  add :token_created_at, :utc_datetime
   add :user_id, references(:users, on_delete: :delete_all)
 
   timestamps

--- a/lib/coherence.ex
+++ b/lib/coherence.ex
@@ -95,8 +95,8 @@ defmodule Coherence do
   Adds the following database field to your User model with the generated migration:
 
       add :sign_in_count, :integer, default: 0  # how many times the user has logged in
-      add :current_sign_in_at, :datetime        # the current login timestamp
-      add :last_sign_in_at, :datetime           # the timestamp of the previous login
+      add :current_sign_in_at, :utc_datetime        # the current login timestamp
+      add :last_sign_in_at, :utc_datetime           # the timestamp of the previous login
       add :current_sign_in_ip, :string          # the current login IP adddress
       add :last_sign_in_ip, :string             # the IP address of the previous login
 
@@ -116,7 +116,7 @@ defmodule Coherence do
 
       add :failed_attempts, :integer, default: 0
       add :unlock_token, :string
-      add :locked_at, :datetime
+      add :locked_at, :utc_datetime
 
   ### Unlockable with Token
 
@@ -146,7 +146,7 @@ defmodule Coherence do
       create table(:rememberables) do
         add :series_hash, :string
         add :token_hash, :string
-        add :token_created_at, :datetime
+        add :token_created_at, :utc_datetime
         add :user_id, references(:users, on_delete: :delete_all)
 
         timestamps

--- a/lib/coherence/controllers/confirmation_controller.ex
+++ b/lib/coherence/controllers/confirmation_controller.ex
@@ -9,7 +9,6 @@ defmodule Coherence.ConfirmationController do
   use Timex
 
   alias Coherence.{ConfirmableService, Messages}
-  alias Ecto.DateTime
   alias Coherence.Schemas
 
   require Logger
@@ -108,7 +107,7 @@ defmodule Coherence.ConfirmationController do
         else
           changeset = Controller.changeset(:confirmation, user_schema, user, %{
             confirmation_token: nil,
-            confirmed_at: DateTime.utc,
+            confirmed_at: DateTime.utc_now,
           })
           case Config.repo.update(changeset) do
             {:ok, _user} ->

--- a/lib/coherence/controllers/controller.ex
+++ b/lib/coherence/controllers/controller.ex
@@ -91,7 +91,7 @@ defmodule Coherence.Controller do
   @doc """
   Test if a datetime has expired.
 
-  Convert the datetime from Ecto.DateTime format to Timex format to do
+  Convert the datetime from DateTime format to Timex format to do
   the comparison given the time during in opts.
 
   ## Examples
@@ -99,13 +99,12 @@ defmodule Coherence.Controller do
       expired?(user.expire_at, days: 5)
       expired?(user.expire_at, minutes: 10)
 
-      iex> Ecto.DateTime.utc
+      iex> DateTime.utc_now
       ...> |> Coherence.Controller.expired?(days: 1)
       false
 
-      iex> Ecto.DateTime.utc
+      iex> DateTime.utc_now
       ...> |> Coherence.Controller.shift(days: -2)
-      ...> |> Ecto.DateTime.cast!
       ...> |> Coherence.Controller.expired?(days: 1)
       true
   """
@@ -116,21 +115,19 @@ defmodule Coherence.Controller do
   end
 
   @doc """
-  Shift a Ecto.DateTime.
+  Shift a DateTime.
 
   ## Examples
 
-      iex> Ecto.DateTime.cast!("2016-10-10 10:10:10")
+      iex> {:ok, datetime, _} = DateTime.from_iso8601("2016-10-10 10:10:10Z")
+      iex> datetime
       ...> |> Coherence.Controller.shift(days: -2)
-      ...> |> Ecto.DateTime.cast!
       ...> |> to_string
-      "2016-10-08 10:10:10"
+      "2016-10-08 10:10:10Z"
   """
   @spec shift(struct, Keyword.t) :: struct
   def shift(datetime, opts) do
     datetime
-    |> Ecto.DateTime.to_erl
-    |> Timex.to_datetime
     |> Timex.shift(opts)
   end
 
@@ -173,7 +170,7 @@ defmodule Coherence.Controller do
       token = random_string 48
       url = router_helpers().confirmation_url(conn, :edit, token)
       Logger.debug "confirmation email url: #{inspect url}"
-      dt = Ecto.DateTime.utc
+      dt = DateTime.utc_now
       user
       |> user_schema.changeset(%{confirmation_token: token,
         confirmation_sent_at: dt,
@@ -221,7 +218,7 @@ defmodule Coherence.Controller do
   can set this data far in the future to do a pseudo permanent lock.
   """
   @spec lock!(Ecto.Schema.t, struct) :: schema_or_error
-  def lock!(user, locked_at \\ Ecto.DateTime.utc) do
+  def lock!(user, locked_at \\ DateTime.utc_now) do
     user_schema = Config.user_schema
     changeset = user_schema.lock user, locked_at
     if user_schema.locked?(user) do

--- a/lib/coherence/controllers/password_controller.ex
+++ b/lib/coherence/controllers/password_controller.ex
@@ -58,7 +58,7 @@ defmodule Coherence.PasswordController do
         token = random_string 48
         url = router_helpers().password_url(conn, :edit, token)
         # Logger.debug "reset email url: #{inspect url}"
-        dt = Ecto.DateTime.utc
+        dt = DateTime.utc_now
         Config.repo.update! Controller.changeset(:password, user_schema, user,
           %{reset_password_token: token, reset_password_sent_at: dt})
 

--- a/lib/coherence/controllers/session_controller.ex
+++ b/lib/coherence/controllers/session_controller.ex
@@ -202,7 +202,7 @@ defmodule Coherence.SessionController do
             |> track_lock(user, user.__struct__.trackable_table?())
           {put_flash(new_conn, :error,
             Messages.backend().maximum_login_attempts_exceeded()),
-            %{locked_at: Ecto.DateTime.utc()}}
+            %{locked_at: DateTime.utc_now()}}
         true ->
           {put_flash(conn, :error,
             Messages.backend().incorrect_login_or_password(login_field:

--- a/lib/coherence/schema.ex
+++ b/lib/coherence/schema.ex
@@ -198,7 +198,7 @@ defmodule Coherence.Schema do
 
         Returns a changeset ready for Repo.update
         """
-        def lock(user, locked_at \\ Ecto.DateTime.utc) do
+        def lock(user, locked_at \\ DateTime.utc_now) do
           Config.user_schema.changeset(user, %{locked_at: locked_at})
         end
 
@@ -214,7 +214,7 @@ defmodule Coherence.Schema do
         deprecated! Please use Coherence.ControllerHelpers.lock!/1.
         """
 
-        def lock!(user, locked_at \\ Ecto.DateTime.utc) do
+        def lock!(user, locked_at \\ DateTime.utc_now) do
           IO.warn "#{inspect Config.user_schema}.lock!/1 has been deprecated. Please use Coherence.ControllerHelpers.lock!/1 instead."
           changeset = Config.user_schema.changeset(user, %{locked_at: locked_at})
           if locked?(user) do
@@ -341,7 +341,7 @@ defmodule Coherence.Schema do
 
           # recoverable
           field :reset_password_token, :string
-          field :reset_password_sent_at, Ecto.DateTime
+          field :reset_password_sent_at, :utc_datetime
 
           timestamps
         end
@@ -361,15 +361,15 @@ defmodule Coherence.Schema do
 
       if Coherence.Config.has_option(:recoverable) do
         field :reset_password_token, :string
-        field :reset_password_sent_at, Ecto.DateTime
+        field :reset_password_sent_at, :utc_datetime
       end
       if Coherence.Config.has_option(:rememberable) do
-        field :remember_created_at, Ecto.DateTime
+        field :remember_created_at, :utc_datetime
       end
       if Coherence.Config.has_option(:trackable) do
         field :sign_in_count, :integer, default: 0
-        field :current_sign_in_at, Ecto.DateTime
-        field :last_sign_in_at, Ecto.DateTime
+        field :current_sign_in_at, :utc_datetime
+        field :last_sign_in_at, :utc_datetime
         field :current_sign_in_ip, :string
         field :last_sign_in_ip, :string
       end
@@ -378,15 +378,15 @@ defmodule Coherence.Schema do
       end
       if Coherence.Config.has_option(:lockable) do
         field :failed_attempts, :integer, default: 0
-        field :locked_at, Ecto.DateTime
+        field :locked_at, :utc_datetime
       end
       if Coherence.Config.has_option(:unlockable_with_token) do
         field :unlock_token, :string
       end
       if Coherence.Config.has_option(:confirmable) do
         field :confirmation_token, :string
-        field :confirmed_at, Ecto.DateTime
-        field :confirmation_sent_at, Ecto.DateTime
+        field :confirmed_at, :utc_datetime
+        field :confirmation_sent_at, :utc_datetime
         # field :unconfirmed_email, :string
       end
     end

--- a/lib/coherence/services/confirmable_service.ex
+++ b/lib/coherence/services/confirmable_service.ex
@@ -63,7 +63,7 @@ defmodule Coherence.ConfirmableService do
         Returns a changeset ready for Repo.update
         """
         def confirm(user) do
-          Schemas.change_user(user, %{confirmed_at: Ecto.DateTime.utc, confirmation_token: nil})
+          Schemas.change_user(user, %{confirmed_at: DateTime.utc_now, confirmation_token: nil})
         end
 
         @doc """
@@ -75,7 +75,7 @@ defmodule Coherence.ConfirmableService do
         """
         def confirm!(user) do
           IO.warn "#{inspect Config.user_schema}.confirm!/1 has been deprecated. Please use Coherence.ControllerHelpers.confirm!/1 instead."
-          changeset = Schemas.change_user(user, %{confirmed_at: Ecto.DateTime.utc, confirmation_token: nil})
+          changeset = Schemas.change_user(user, %{confirmed_at: DateTime.utc_now, confirmation_token: nil})
           if confirmed? user do
             changeset = Ecto.Changeset.add_error changeset, :confirmed_at, Messages.backend().already_confirmed()
             {:error, changeset}
@@ -97,7 +97,7 @@ defmodule Coherence.ConfirmableService do
   """
   @spec confirm(Ecto.Schema.t) :: Ecto.Changeset.t
   def confirm(user) do
-    Schemas.change_user(user, %{confirmed_at: Ecto.DateTime.utc, confirmation_token: nil})
+    Schemas.change_user(user, %{confirmed_at: DateTime.utc_now, confirmation_token: nil})
   end
 
   @doc """
@@ -109,7 +109,7 @@ defmodule Coherence.ConfirmableService do
   """
   @spec confirm!(Ecto.Schema.t) :: Ecto.Changeset.t | {:error, Ecto.Changeset.t}
   def confirm!(user) do
-    changeset = Schemas.change_user(user, %{confirmed_at: Ecto.DateTime.utc, confirmation_token: nil})
+    changeset = Schemas.change_user(user, %{confirmed_at: DateTime.utc_now, confirmation_token: nil})
 
     if confirmed? user do
       changeset = Ecto.Changeset.add_error changeset, :confirmed_at, Messages.backend().already_confirmed()

--- a/lib/coherence/services/lockable_service.ex
+++ b/lib/coherence/services/lockable_service.ex
@@ -8,7 +8,7 @@ defmodule Coherence.LockableService do
   This option adds the following fields to the user schema:
 
   * :failed_attempts, :integer - The number of failed login attempts.
-  * :locked_at, :datetime - The time and date when the account was locked.
+  * :locked_at, :utc_datetime - The time and date when the account was locked.
 
   The following configuration is used to customize lockable behavior:
 

--- a/lib/coherence/services/password_service.ex
+++ b/lib/coherence/services/password_service.ex
@@ -29,7 +29,7 @@ defmodule Coherence.PasswordService do
   """
   def reset_password_token(user) do
     token = Controller.random_string 48
-    dt = Ecto.DateTime.utc
+    dt = DateTime.utc_now
     :password
     |> Controller.changeset(user.__struct__, user,
       %{reset_password_token: token, reset_password_sent_at: dt})

--- a/lib/coherence/services/trackable_service.ex
+++ b/lib/coherence/services/trackable_service.ex
@@ -70,7 +70,7 @@ defmodule Coherence.TrackableService do
     changeset = Controller.changeset(:session, user.__struct__, user,
       %{
         sign_in_count: user.sign_in_count + 1,
-        current_sign_in_at: Ecto.DateTime.utc,
+        current_sign_in_at: DateTime.utc_now,
         current_sign_in_ip: ip,
         last_sign_in_at: last_at,
         last_sign_in_ip: last_ip
@@ -95,7 +95,7 @@ defmodule Coherence.TrackableService do
       %{
         action: "login",
         sign_in_count: trackable.sign_in_count + 1,
-        current_sign_in_at: Ecto.DateTime.utc,
+        current_sign_in_at: DateTime.utc_now,
         current_sign_in_ip: ip,
         last_sign_in_at: last_at,
         last_sign_in_ip: last_ip,
@@ -213,7 +213,7 @@ defmodule Coherence.TrackableService do
   end
 
   defp last_at_and_ip(conn, schema) do
-    now = Ecto.DateTime.utc
+    now = DateTime.utc_now
     ip = conn.peer |> elem(0) |> inspect
     cond do
       is_nil(schema.last_sign_in_at) and is_nil(schema.current_sign_in_at) ->

--- a/priv/templates/coh.gen.controllers/controllers/coherence/confirmation_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/confirmation_controller.ex
@@ -9,7 +9,6 @@ defmodule <%= web_base %>.Coherence.ConfirmationController do
   use Timex
 
   alias Coherence.{ConfirmableService, Messages}
-  alias Ecto.DateTime
   alias Coherence.Schemas
 
   require Logger

--- a/priv/templates/coh.gen.controllers/controllers/coherence/password_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/password_controller.ex
@@ -58,7 +58,7 @@ defmodule <%= web_base %>.Coherence.PasswordController do
         token = random_string 48
         url = router_helpers().password_url(conn, :edit, token)
         # Logger.debug "reset email url: #{inspect url}"
-        dt = Ecto.DateTime.utc
+        dt = DateTime.utc_now
         Config.repo.update! Controller.changeset(:password, user_schema, user,
           %{reset_password_token: token, reset_password_sent_at: dt})
 

--- a/priv/templates/coh.gen.controllers/controllers/coherence/session_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/session_controller.ex
@@ -202,7 +202,7 @@ defmodule <%= web_base %>.Coherence.SessionController do
             |> track_lock(user, user.__struct__.trackable_table?())
           {put_flash(new_conn, :error,
             Messages.backend().maximum_login_attempts_exceeded()),
-            %{locked_at: Ecto.DateTime.utc()}}
+            %{locked_at: DateTime.utc_now()}}
         true ->
           {put_flash(conn, :error,
             Messages.backend().incorrect_login_or_password(login_field:

--- a/priv/templates/coh.install/models/coherence/rememberable.ex
+++ b/priv/templates/coh.install/models/coherence/rememberable.ex
@@ -15,7 +15,7 @@ defmodule <%= base %>.Coherence.Rememberable do
   schema "rememberables" do
     field :series_hash, :string
     field :token_hash, :string
-    field :token_created_at, Timex.Ecto.DateTime
+    field :token_created_at, :utc_datetime
     belongs_to :user, Module.concat(Config.module, Config.user_schema)<%= if use_binary_id?, do: ", type: :binary_id", else: "" %>
 
     timestamps()

--- a/priv/templates/coh.install/models/coherence/trackable.ex
+++ b/priv/templates/coh.install/models/coherence/trackable.ex
@@ -17,8 +17,8 @@ defmodule <%= base %>.Coherence.Trackable do
   schema "trackables" do
     field :action, :string, null: false
     field :sign_in_count, :integer, default: 0
-    field :current_sign_in_at, Ecto.DateTime
-    field :last_sign_in_at, Ecto.DateTime
+    field :current_sign_in_at, :utc_datetime
+    field :last_sign_in_at, :utc_datetime
     field :current_sign_in_ip, :string
     field :last_sign_in_ip, :string
     belongs_to :user, Config.user_schema<%= if use_binary_id?, do: ", type: :binary_id", else: "" %>

--- a/test/controllers/controller_helpers_test.exs
+++ b/test/controllers/controller_helpers_test.exs
@@ -34,7 +34,7 @@ defmodule CoherenceTest.Controller do
   end
 
   test "unlock!" do
-    user = insert_user(%{locked_at: Ecto.DateTime.utc})
+    user = insert_user(%{locked_at: DateTime.utc_now})
     assert User.locked?(user)
     {:ok, user} = Controller.unlock!(user)
     refute User.locked?(user)

--- a/test/controllers/password_controller_test.exs
+++ b/test/controllers/password_controller_test.exs
@@ -46,7 +46,7 @@ defmodule CoherenceTest.PasswordController do
 
     test "valid token has expired", %{conn: conn} do
       token = random_string 48
-      {:ok, sent_at} = Ecto.DateTime.cast("2016-01-01 00:00:00")
+      {:ok, sent_at, _} = DateTime.from_iso8601("2016-01-01 00:00:00Z")
       insert_user(%{reset_password_sent_at: sent_at, reset_password_token: token})
       params = %{"id" => token}
       conn = get conn, password_path(conn, :edit, token), params
@@ -56,7 +56,7 @@ defmodule CoherenceTest.PasswordController do
 
     test "valid token hasn't expired", %{conn: conn} do
       token = random_string 48
-      insert_user(%{reset_password_sent_at: Ecto.DateTime.utc, reset_password_token: token})
+      insert_user(%{reset_password_sent_at: DateTime.utc_now, reset_password_token: token})
       params = %{"id" => token}
       conn = get conn, password_path(conn, :edit, token), params
       assert conn.private[:phoenix_template] == "edit.html"
@@ -67,7 +67,7 @@ defmodule CoherenceTest.PasswordController do
   describe "update" do
     test "valid token", %{conn: conn} do
       token = random_string 48
-      user = insert_user(%{reset_password_sent_at: Ecto.DateTime.utc, reset_password_token: token})
+      user = insert_user(%{reset_password_sent_at: DateTime.utc_now, reset_password_token: token})
       old_password_hash = user.password_hash
       params = %{"password" => %{reset_password_token: token, password: "123123", password_confirmation: "123123"}}
       put(conn, password_path(conn, :update, user.id), params)
@@ -79,7 +79,7 @@ defmodule CoherenceTest.PasswordController do
 
     test "invalid reset password token", %{conn: conn} do
       token = random_string 48
-      user = insert_user(%{reset_password_sent_at: Ecto.DateTime.utc, reset_password_token: token})
+      user = insert_user(%{reset_password_sent_at: DateTime.utc_now, reset_password_token: token})
       old_password_hash = user.password_hash
       old_sent_at = user.reset_password_sent_at
       params = %{"password" => %{reset_password_token: "1234567890", password: "123123", password_confirmation: "123123"}}
@@ -92,7 +92,7 @@ defmodule CoherenceTest.PasswordController do
     end
 
     test "valid token has expired, reset token gets removed", %{conn: conn} do
-      {:ok, sent_at} = Ecto.DateTime.cast("2016-01-01 00:00:00")
+      {:ok, sent_at, _} = DateTime.from_iso8601("2016-01-01 00:00:00Z")
       token = random_string 48
       user = insert_user(%{reset_password_sent_at: sent_at, reset_password_token: token})
       old_password_hash = user.password_hash

--- a/test/schema_test.exs
+++ b/test/schema_test.exs
@@ -67,7 +67,7 @@ defmodule CoherenceTest.Schema do
 
   test "confirmed?" do
     refute User.confirmed?(%User{})
-    assert User.confirmed?(%User{confirmed_at: Ecto.DateTime.utc})
+    assert User.confirmed?(%User{confirmed_at: DateTime.utc_now})
   end
 
   test "confirm" do
@@ -78,6 +78,6 @@ defmodule CoherenceTest.Schema do
 
   test "locked?" do
     refute User.locked?(%User{})
-    assert User.locked?(%User{locked_at: Ecto.DateTime.utc})
+    assert User.locked?(%User{locked_at: DateTime.utc_now})
   end
 end

--- a/test/services/trackable_service_test.exs
+++ b/test/services/trackable_service_test.exs
@@ -33,7 +33,7 @@ defmodule CoherenceTest.TrackableService do
       assert current_user.sign_in_count == 1
       assert current_user.current_sign_in_at
       assert current_user.current_sign_in_ip == "{127, 0, 0, 1}"
-      assert current_user.last_sign_in_at == current_user.current_sign_in_at
+      assert DateTime.to_unix(current_user.last_sign_in_at) == DateTime.to_unix(current_user.current_sign_in_at)
       assert current_user.last_sign_in_ip == current_user.current_sign_in_ip
     end
     test "2nd login", %{conn: conn, user: user} do
@@ -74,7 +74,7 @@ defmodule CoherenceTest.TrackableService do
       assert trackable.sign_in_count == 1
       assert trackable.current_sign_in_at
       assert trackable.current_sign_in_ip == "{127, 0, 0, 1}"
-      assert trackable.last_sign_in_at == trackable.current_sign_in_at
+      assert DateTime.to_unix(trackable.last_sign_in_at) == DateTime.to_unix(trackable.current_sign_in_at)
       assert trackable.last_sign_in_ip == trackable.current_sign_in_ip
       assert trackable.user_id == user.id
       assert trackable.action == "login"

--- a/test/support/schema.exs
+++ b/test/support/schema.exs
@@ -185,7 +185,7 @@ defmodule TestCoherence.Coherence.Rememberable do
   schema "rememberables" do
     field :series_hash, :string
     field :token_hash, :string
-    field :token_created_at, Timex.Ecto.DateTime
+    field :token_created_at, :utc_datetime
     belongs_to :user, Module.concat(Config.module, Config.user_schema)
     timestamps()
   end
@@ -217,8 +217,8 @@ defmodule TestCoherence.Coherence.Trackable do
   schema "trackables" do
     field :action, :string, null: false
     field :sign_in_count, :integer, default: 0
-    field :current_sign_in_at, Ecto.DateTime
-    field :last_sign_in_at, Ecto.DateTime
+    field :current_sign_in_at, :utc_datetime
+    field :last_sign_in_at, :utc_datetime
     field :current_sign_in_ip, :string
     field :last_sign_in_ip, :string
     belongs_to :user, Config.user_schema


### PR DESCRIPTION
This removes the warning:

```
warning: Ecto.DateTime is deprecated, plese use :naive_datetime instead
```

when using the `coherence_schema` macro in the user schema.

I chose to use `:utc_datetime` instead of the suggested `:naive_datetime` because I think it’s better to handle UTC datetimes instead of timezone-less datetimes.

Tell me what you think!