### PR TITLE
Feature - Custom routes for registrations and sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,9 +284,9 @@ scope "/" do
     custom_routes: %{registratons_edit: "/accounts/edit", ...}
   ]
 end
-``
+```
 
-# Phoenix Channel Authentication
+### Phoenix Channel Authentication
 
 Coherence supports channel authentication using `Phoenix.Token`. To enable channel authentication do the following:
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Coherence is a full featured, configurable authentication system for Phoenix, wi
 * [Lockable](#lockable): locks an account when a specified number of failed sign-in attempts has been exceeded.
 * [Unlockable With Token](#unlockable-with-token): provides a link to send yourself an unlock email.
 * [Rememberable](#remember-me): provides persistent login with 'Remember me?' check box on login page.
-
 Coherence provides flexibility by adding namespaced templates and views for only the options specified by the `mix coh.install` command. This boiler plate code is added to your `lib/my_project/web/templates/coherence` and `lib/my_project/web/views/coherence` directories.
 
 Once the boilerplate has been generated, you are free to customize the source as required.
@@ -245,7 +244,49 @@ config :coherence,
   max_failed_login_attempts: 3
 ```
 
-## Phoenix Channel Authentication
+### Custom registration and sessions routes
+
+Coherence supports custom routes for registration and login. These configurations can be set globally or scoped.
+
+Which routes can be custom?
+
+```
+%{
+  registrations_new:  "/registrations/new",
+  registrations:      "/registrations",
+  passwords:          "/passwords",
+  confirmations:      "/confirmations",
+  unlocks:            "/unlocks",
+  invitations:        "/invitations",
+  invitations_create: "/invitations/create",
+  invitations_resend: "/invitations/:id/resend",
+  sessions:           "/sessions",
+  registrations_edit: "/registrations/edit"
+}
+```
+
+To set them globally add the following to you configuration:
+
+
+
+```elixir
+config :coherence,
+  default_routes: %{
+    registrations_edit: "/accounts/edit", ...},
+```
+
+To set them scoped for each mode (protected, public, etc..):
+
+```elixir
+scope "/" do
+  pipe_through :protected
+  coherence_routes :protected, [
+    custom_routes: %{registratons_edit: "/accounts/edit", ...}
+  ]
+end
+``
+
+# Phoenix Channel Authentication
 
 Coherence supports channel authentication using `Phoenix.Token`. To enable channel authentication do the following:
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ config :coherence,
   max_failed_login_attempts: 3
 ```
 
-### Custom registration and sessions routes
+## Custom registration and sessions routes
 
 Coherence supports custom routes for registration and login. These configurations can be set globally or scoped.
 
@@ -286,7 +286,7 @@ scope "/" do
 end
 ```
 
-### Phoenix Channel Authentication
+## Phoenix Channel Authentication
 
 Coherence supports channel authentication using `Phoenix.Token`. To enable channel authentication do the following:
 

--- a/lib/coherence/config.ex
+++ b/lib/coherence/config.ex
@@ -220,4 +220,26 @@ defmodule Coherence.Config do
     !!Application.get_env(:coherence, Module.concat(web_module(), Coherence.Mailer))
   end
 
+  def default_routes do
+    case Application.get_env(:coherence, :default_routes) do
+      nil -> 
+        %{
+          registrations_new:  "/registrations/new",
+          registrations:      "/registrations",
+          passwords:          "/passwords",
+          confirmations:      "/confirmations",
+          unlocks:            "/unlocks",
+          invitations:        "/invitations",
+          invitations_create: "/invitations/create",
+          invitations_resend: "/invitations/:id/resend",
+          sessions:           "/sessions",
+          registrations_edit: "/registrations/edit"
+        }
+      %{} = config -> 
+        config
+      true -> 
+        Logger.info "The configuration for default_routes must be a map"
+        nil
+    end
+  end
 end

--- a/lib/coherence/router.ex
+++ b/lib/coherence/router.ex
@@ -65,16 +65,18 @@ defmodule Coherence.Router do
       end
   """
   defmacro coherence_routes(mode \\ [], opts \\ []) do
-    {mode, _opts} = case mode do
+    {mode, opts} = case mode do
       :private ->
         IO.warn "coherence_routes :private has been deprecated. Please use :protected instead."
         {:protected, opts}
       mode when is_atom(mode) -> {mode, opts}
-      []                      -> {:public, []}
+      []                      -> {:public, opts}
       opts when is_list(opts) -> {:all, opts}
     end
     quote location: :keep do
       mode = unquote(mode)
+      opts = unquote(opts)
+      routes = Map.merge(Coherence.Config.default_routes, opts[:custom_routes] || %{})
 
       if mode == :public && Module.get_attribute(__MODULE__, :__COHERENCE_PROTECTED__) do
         raise "Protected routes must follow public routes. Please move 'coherence_routes :protected' below 'coherence_routes'."
@@ -86,62 +88,62 @@ defmodule Coherence.Router do
       if mode == :all or mode == :public do
         Enum.each([:new, :create], fn(action) ->
           if Coherence.Config.has_action?(:authenticatable, action) do
-            resources "/sessions", Coherence.SessionController, only: [action]
+            resources "#{routes.sessions}", Coherence.SessionController, only: [action]
           end
         end)
         if Coherence.Config.has_action?(:registerable, :new) do
-          get "/registrations/new", Coherence.RegistrationController, :new
+          get "#{routes.registrations_new}", Coherence.RegistrationController, :new
         end
         if Coherence.Config.has_action?(:registerable, :create) do
-          post "/registrations", Coherence.RegistrationController, :create
+          post "#{routes.registrations}", Coherence.RegistrationController, :create
         end
         Enum.each([:new, :create, :edit, :update], fn(action) ->
           if Coherence.Config.has_action?(:recoverable, action) do
-            resources "/passwords", Coherence.PasswordController, only: [action]
+            resources "#{routes.passwords}", Coherence.PasswordController, only: [action]
           end
         end)
         Enum.each([:edit, :new, :create], fn(action) ->
           if Coherence.Config.has_action?(:confirmable, action) do
-            resources "/confirmations", Coherence.ConfirmationController, only: [action]
+            resources "#{routes.confirmations}", Coherence.ConfirmationController, only: [action]
           end
         end)
         Enum.each([:new, :create, :edit], fn(action) ->
           if Coherence.Config.has_action?(:unlockable_with_token, action) do
-            resources "/unlocks", Coherence.UnlockController, only: [action]
+            resources "#{routes.unlocks}", Coherence.UnlockController, only: [action]
           end
         end)
         if Coherence.Config.has_action?(:invitable, :edit) do
-          resources "/invitations", Coherence.InvitationController, only: [:edit]
+          resources "#{routes.invitations}", Coherence.InvitationController, only: [:edit]
         end
         if Coherence.Config.has_action?(:invitable, :create_user) do
-          post "/invitations/create", Coherence.InvitationController, :create_user
+          post "#{routes.invitations_create}", Coherence.InvitationController, :create_user
         end
       end
       if mode == :all or mode == :protected do
         if Coherence.Config.has_action?(:invitable, :new) do
-          resources "/invitations", Coherence.InvitationController, only: [:new]
+          resources "#{routes.invitations}", Coherence.InvitationController, only: [:new]
         end
         if Coherence.Config.has_action?(:invitable, :create) do
-          resources "/invitations", Coherence.InvitationController, only: [:create]
+          resources "#{routes.invitations}", Coherence.InvitationController, only: [:create]
         end
         if Coherence.Config.has_action?(:invitable, :resend) do
-          get "/invitations/:id/resend", Coherence.InvitationController, :resend
+          get "#{routes.invitations_resend}", Coherence.InvitationController, :resend
         end
         if Coherence.Config.has_action?(:authenticatable, :delete) do
-          delete "/sessions", Coherence.SessionController, :delete
+          delete "#{routes.sessions}", Coherence.SessionController, :delete
         end
         if Coherence.Config.has_action?(:registerable, :show) do
-          get "/registrations", Coherence.RegistrationController, :show
+          get "#{routes.registrations}", Coherence.RegistrationController, :show
         end
         if Coherence.Config.has_action?(:registerable, :update) do
-          put "/registrations", Coherence.RegistrationController, :update
-          patch "/registrations", Coherence.RegistrationController, :update
+          put "#{routes.registrations}", Coherence.RegistrationController, :update
+          patch "#{routes.registrations}", Coherence.RegistrationController, :update
         end
         if Coherence.Config.has_action?(:registerable, :edit) do
-          get "/registrations/edit", Coherence.RegistrationController, :edit
+          get "#{routes.registrations_edit}", Coherence.RegistrationController, :edit
         end
         if Coherence.Config.has_action?(:registerable, :delete) do
-          delete "/registrations", Coherence.RegistrationController, :delete
+          delete "#{routes.registrations}", Coherence.RegistrationController, :delete
         end
       end
     end

--- a/test/config_test.exs
+++ b/test/config_test.exs
@@ -51,4 +51,27 @@ defmodule CoherenceTest.Config do
     Application.put_env(:coherence, :opts, [a: [:create]])
     refute Config.has_action?(:a, :new)
   end
+
+  describe "default_routes/0" do
+    test "when are set configured globally" do
+      Application.put_env(:coherence, :default_routes, %{registrations: "memberships"})
+      assert Config.default_routes == %{registrations: "memberships"}
+    end
+
+    test "when are not configured" do
+      Application.put_env(:coherence, :default_routes, nil)
+      assert Config.default_routes == %{
+        registrations_new:  "/registrations/new",
+        registrations:      "/registrations",
+        passwords:          "/passwords",
+        confirmations:      "/confirmations",
+        unlocks:            "/unlocks",
+        invitations:        "/invitations",
+        invitations_create: "/invitations/create",
+        invitations_resend: "/invitations/:id/resend",
+        sessions:           "/sessions",
+        registrations_edit: "/registrations/edit"
+      }
+    end
+  end
 end


### PR DESCRIPTION
Hello, I have taken the freedom of creating this PR changing the way coherence handles default routes such as "registrations/edit" and "sessions". 

### Custom registration and sessions routes

Coherence will support custom routes for registration and login. These configurations can be set globally or scoped.

Which routes can be customised?

```
%{
  registrations_new:  "/registrations/new",
  registrations:      "/registrations",
  passwords:          "/passwords",
  confirmations:      "/confirmations",
  unlocks:            "/unlocks",
  invitations:        "/invitations",
  invitations_create: "/invitations/create",
  invitations_resend: "/invitations/:id/resend",
  sessions:           "/sessions",
  registrations_edit: "/registrations/edit"
}
```

To set them globally you will need to add the following to you configuration:


```elixir
config :coherence,
  default_routes: %{
    registrations_edit: "/accounts/edit", ...},
```

To set them scoped for each mode (protected, public, etc..):

```elixir
scope "/" do
  pipe_through :protected
  coherence_routes :protected, [
    custom_routes: %{registratons_edit: "/accounts/edit", ...}
  ]
end
```

This will not affect older versions of the package. It will work as it used to by default.

Please @smpallen99 let me know what you think :) 