### PR TITLE
Explicitly specify that the protected block needs to be added wrt router.ex in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ defmodule MyProjectWeb.Router do
     plug Coherence.Authentication.Session  # Add this
   end
 
+  # Add this block
   pipeline :protected do
     plug :accepts, ["html"]
     plug :fetch_session


### PR DESCRIPTION
**Context**:

I tried to follow the coherence repo README instructions to setup things as part of a new Phoenix 1.3.0 app and the only things that I got by default in my `router.ex` as part of running the below cmds was:

Commands:
1. `mix phx.new user_auth_coh_demo` and then adding coherence to the dependencies in `mix.exs`
2.  `mix coh.install --full-invitable`

In the `router.ex` file:

```elixir
defmodule UserAuthCohDemoWeb.Router do
  use UserAuthCohDemoWeb, :router

  pipeline :browser do
    plug :accepts, ["html"]
    plug :fetch_session
    plug :fetch_flash
    plug :protect_from_forgery
    plug :put_secure_browser_headers
  end

  pipeline :api do
    plug :accepts, ["json"]
  end

  scope "/", UserAuthCohDemoWeb do
    pipe_through :browser # Use the default browser stack

    get "/", PageController, :index
  end

  # Other scopes may use custom stacks.
  # scope "/api", UserAuthCohDemoWeb do
  #   pipe_through :api
  # end
end

```

This gave me an impression that the protected block(specified in the README) needs to be explicitly added and hence I've submitted a PR to explicitly specify the same. Please feel free to correct me if I'm missing something.

Thank you.