### PR TITLE
Saving IP addresses as strings rather than tuples

### DIFF
--- a/lib/coherence/config.ex
+++ b/lib/coherence/config.ex
@@ -13,6 +13,7 @@ defmodule Coherence.Config do
   * :repo: the module name of your Repo (`repo: MyProject.Repo`)
   * :user_schema
   * :schema_key
+  * :confimarion_url                                  - Must include :token
   * :logged_out_url
   * :logged_in_url
   * :email_from                                       - Deprecated. Use `email_from_name` and `email_from_email` instead
@@ -78,6 +79,7 @@ defmodule Coherence.Config do
     :repo,
     :user_schema,
     :schema_key,
+    :confimarion_url,
     :logged_out_url,
     :logged_in_url,
     :email_from_name,

--- a/lib/coherence/controllers/controller.ex
+++ b/lib/coherence/controllers/controller.ex
@@ -161,7 +161,7 @@ defmodule Coherence.Controller do
   end
 
   def get_confirmation_url(conn, token) do
-    case Config.logged_in_url do
+    case Config.confimarion_url do
       nil -> router_helpers().confirmation_url(conn, :edit, token)
       url -> url
         |> String.replace(":token", token)

--- a/lib/coherence/controllers/controller.ex
+++ b/lib/coherence/controllers/controller.ex
@@ -160,6 +160,14 @@ defmodule Coherence.Controller do
     end
   end
 
+  def get_confirmation_url(conn, token) do
+    case Config.logged_in_url do
+      nil -> router_helpers().confirmation_url(conn, :edit, token)
+      url -> url
+        |> String.replace(":token", token)
+    end
+  end
+
   @doc """
   Send confirmation email with token.
 
@@ -169,7 +177,7 @@ defmodule Coherence.Controller do
   def send_confirmation(conn, user, user_schema) do
     if user_schema.confirmable? do
       token = random_string 48
-      url = router_helpers().confirmation_url(conn, :edit, token)
+      url = get_confirmation_url(conn, token)
       Logger.debug "confirmation email url: #{inspect url}"
       dt = NaiveDateTime.utc_now()
       user

--- a/lib/coherence/schema.ex
+++ b/lib/coherence/schema.ex
@@ -370,8 +370,8 @@ defmodule Coherence.Schema do
         field :sign_in_count, :integer, default: 0
         field :current_sign_in_at, :naive_datetime
         field :last_sign_in_at, :naive_datetime
-        field :current_sign_in_ip, :string
-        field :last_sign_in_ip, :string
+        field :current_sign_in_ip, EctoFields.IP
+        field :last_sign_in_ip, EctoFields.IP
       end
       if Coherence.Config.has_option(:trackable_table) do
         has_many :trackables, Module.concat(Config.module, Coherence.Trackable)

--- a/lib/coherence/services/trackable_service.ex
+++ b/lib/coherence/services/trackable_service.ex
@@ -81,8 +81,8 @@ defmodule Coherence.TrackableService do
         Config.auth_module
         |> apply(Config.update_login, [conn, user, [id_key: Config.schema_key]])
         |> Conn.assign(Config.assigns_key, user)
-      {:error, _changeset} ->
-        Logger.error ("Failed to update tracking!")
+      {:error, changeset} ->
+        Logger.error ("Failed to update tracking: #{changeset}")
         conn
     end
   end

--- a/lib/coherence/services/trackable_service.ex
+++ b/lib/coherence/services/trackable_service.ex
@@ -214,7 +214,7 @@ defmodule Coherence.TrackableService do
 
   defp last_at_and_ip(conn, schema) do
     now = NaiveDateTime.utc_now()
-    ip = conn.peer |> elem(0) |> inspect
+    ip = conn.peer |> elem(0) |> :inet_parse.ntoa |> to_string
     cond do
       is_nil(schema.last_sign_in_at) and is_nil(schema.current_sign_in_at) ->
         {now, ip, ip, now}

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Coherence.Mixfile do
       {:postgrex, ">= 0.0.0", only: :test},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:credo, "~> 0.8", only: [:dev, :test]},
+      {:ecto_fields, "~> 1.0.1"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -9,6 +9,7 @@
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
   "ecto": {:hex, :ecto, "2.2.7", "2074106ff4a5cd9cb2b54b12ca087c4b659ddb3f6b50be4562883c1d763fb031", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, repo: "hexpm", optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, repo: "hexpm", optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, repo: "hexpm", optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, repo: "hexpm", optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, repo: "hexpm", optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, repo: "hexpm", optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, repo: "hexpm", optional: true]}], "hexpm"},
+  "ecto_fields": {:hex, :ecto_fields, "1.0.1", "b7e63b2b8d301c97aee596e67ab90b952139ae88db0580132a239dc9d47ba195", [], [{:ecto, "~> 2.0", [hex: :ecto, repo: "hexpm", optional: false]}], "hexpm"},
   "elixir_make": {:hex, :elixir_make, "0.4.0", "992f38fabe705bb45821a728f20914c554b276838433349d4f2341f7a687cddf", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.1", "37c69d2ef62f24928c1f4fdc7c724ea04aecfdf500c4329185f8e3649c915baf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "exactor": {:hex, :exactor, "2.2.3", "a6972f43bb6160afeb73e1d8ab45ba604cd0ac8b5244c557093f6e92ce582786", [:mix], []},

--- a/test/services/trackable_service_test.exs
+++ b/test/services/trackable_service_test.exs
@@ -32,7 +32,7 @@ defmodule CoherenceTest.TrackableService do
       current_user = conn.assigns[:current_user]
       assert current_user.sign_in_count == 1
       assert current_user.current_sign_in_at
-      assert current_user.current_sign_in_ip == "{127, 0, 0, 1}"
+      assert current_user.current_sign_in_ip == "127.0.0.1"
       assert naive_eq?(current_user.last_sign_in_at, current_user.current_sign_in_at)
       assert current_user.last_sign_in_ip == current_user.current_sign_in_ip
     end
@@ -43,18 +43,18 @@ defmodule CoherenceTest.TrackableService do
       current_user = conn.assigns[:current_user]
       assert current_user.sign_in_count == 2
       assert current_user.current_sign_in_at
-      assert current_user.current_sign_in_ip == "{127, 0, 0, 1}"
+      assert current_user.current_sign_in_ip == "127.0.0.1"
       refute naive_eq?(current_user.last_sign_in_at, current_user.current_sign_in_at)
       assert current_user.last_sign_in_ip == current_user.current_sign_in_ip
     end
     test "different IP", %{conn: conn, user: user} do
       conn = Service.track_login(conn, user, true, false)
       current_user = conn.assigns[:current_user]
-      assert current_user.current_sign_in_ip == "{127, 0, 0, 1}"
+      assert current_user.current_sign_in_ip == "127.0.0.1"
       conn = struct(conn, peer: {{10,10,10,10}, 80})
       conn = Service.track_login(conn, conn.assigns[:current_user], true, false)
       current_user = conn.assigns[:current_user]
-      assert current_user.current_sign_in_ip == "{10, 10, 10, 10}"
+      assert current_user.current_sign_in_ip == "10.10.10.10"
     end
     test "track_logout", %{conn: conn, user: user} do
       conn = Service.track_login(conn, user, true, false)
@@ -73,7 +73,7 @@ defmodule CoherenceTest.TrackableService do
       [trackable] = Trackable |> Repo.all
       assert trackable.sign_in_count == 1
       assert trackable.current_sign_in_at
-      assert trackable.current_sign_in_ip == "{127, 0, 0, 1}"
+      assert trackable.current_sign_in_ip == "127.0.0.1"
       assert naive_eq?(trackable.last_sign_in_at, trackable.current_sign_in_at)
       assert trackable.last_sign_in_ip == trackable.current_sign_in_ip
       assert trackable.user_id == user.id
@@ -108,7 +108,7 @@ defmodule CoherenceTest.TrackableService do
 
       assert t3.action == "login"
       assert t3.current_sign_in_at
-      assert t3.current_sign_in_ip == "{127, 0, 0, 1}"
+      assert t3.current_sign_in_ip == "127.0.0.1"
       assert t3.user_id == user.id
       assert naive_eq?(t2.last_sign_in_at, t3.last_sign_in_at)
       assert t3.last_sign_in_ip == t2.last_sign_in_ip
@@ -116,11 +116,11 @@ defmodule CoherenceTest.TrackableService do
     test "different IP", %{conn: conn, user: user} do
       conn = Service.track_login(conn, user, false, true)
       [t1] = Trackable |> order_by(asc: :id) |> Repo.all
-      assert t1.current_sign_in_ip == "{127, 0, 0, 1}"
+      assert t1.current_sign_in_ip == "127.0.0.1"
       conn = struct(conn, peer: {{10,10,10,10}, 80})
       Service.track_login(conn, user, false, true)
       [_t1, t2] = Trackable |> order_by(asc: :id) |> Repo.all
-      assert t2.current_sign_in_ip == "{10, 10, 10, 10}"
+      assert t2.current_sign_in_ip == "10.10.10.10"
     end
     test "password reset", %{conn: conn, user: user} do
       conn = Service.track_login(conn, user, false, true)


### PR DESCRIPTION
Also adding format validation with https://github.com/jerel/ecto_fields.

This change would be very handy for other services needing to use IP data and not having to reparse the elixir tuple format