### PR TITLE
Fixed in password controller the action create to support subdomains

### DIFF
--- a/lib/coherence/controllers/password_controller.ex
+++ b/lib/coherence/controllers/password_controller.ex
@@ -56,7 +56,8 @@ defmodule Coherence.PasswordController do
         )
       user ->
         token = random_string 48
-        url = router_helpers().password_url(conn, :edit, token)
+        uri = %URI{host: conn.host, port: conn.port}
+        url = router_helpers().password_url(uri, :edit, token)
         # Logger.debug "reset email url: #{inspect url}"
         dt = NaiveDateTime.utc_now()
         Config.repo.update! Controller.changeset(:password, user_schema, user,


### PR DESCRIPTION
Fixed in password controller the action create to generate correctly the URL when the host domain includes a subdomain.

Before the fix we has:

Expected result:
Host: `demo.lvh.me`
`http://demo.lvh.me:4000/passwords/<generated_token>/edit`

Obtained result:
`http://localhost:4000/passwords/<generated_token>/edit`

**Note:** This change no affects the old implementation.

**Note:** I reviewed that this problem does not occur in others actions in the password controller but I do not review it in other controllers.