### PR TITLE
Call update_login explicitly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ Any of the user model's available data can be accessed this way.
 If the user model is changed after login, a call to `update_login` must be done to update the credential store. For example, in your controller update function, call:
 
 ```elixir
-apply(Config.auth_module, Config.update_login, [conn, user, [id_key: Config.schema_key]])
+apply(Coherence.Config.auth_module, Coherence.Config.update_login, [conn, user, [id_key: Coherence.Config.schema_key]])
 ```
 to update the credential store.
 


### PR DESCRIPTION
In a controller, `update_login` works only `Coherence.Config` is used explicitly.
