### PR TITLE
Fix issue when attempting to immediately log in after registering an account

### DIFF
--- a/lib/coherence/controllers/registration_controller.ex
+++ b/lib/coherence/controllers/registration_controller.ex
@@ -70,7 +70,14 @@ defmodule Coherence.RegistrationController do
   defp redirect_or_login(conn, user, params, _) do
     conn
     |> Controller.login_user(user, params)
-    |> respond_with(:session_create_success, %{params: params, user: user})
+    |> respond_with(
+      :session_create_success,
+      %{
+        params: params,
+        user: user,
+        notice: Messages.backend().account_created_successfully(),
+      }
+    )
   end
 
   @doc """

--- a/lib/coherence/messages.ex
+++ b/lib/coherence/messages.ex
@@ -15,6 +15,7 @@ defmodule Coherence.Messages do
   @callback account_already_confirmed() :: binary
   @callback account_is_not_locked() :: binary
   @callback account_updated_successfully() :: binary
+  @callback account_created_successfully() :: binary
   @callback already_logged_in() :: binary
   @callback cant_find_that_token() :: binary
   @callback confirmation_token_expired() :: binary

--- a/priv/templates/coh.install/coherence_messages.ex
+++ b/priv/templates/coh.install/coherence_messages.ex
@@ -24,6 +24,7 @@ defmodule <%= web_base %>.Coherence.Messages do
   def account_already_confirmed, do: dgettext(@domain, "Account already confirmed.")
   def account_is_not_locked, do: dgettext(@domain, "Account is not locked.")
   def account_updated_successfully, do: dgettext(@domain, "Account updated successfully.")
+  def account_created_successfully, do: dgettext(@domain, "Account created successfully.")
   def already_confirmed, do: dgettext(@domain, "already confirmed")
   def already_locked, do: dgettext(@domain, "already locked")
   def already_logged_in, do: dgettext(@domain, "Already logged in.")

--- a/test/support/messages.exs
+++ b/test/support/messages.exs
@@ -24,6 +24,7 @@ defmodule TestCoherenceWeb.Coherence.Messages do
   def account_already_confirmed, do: dgettext(@domain, "Account already confirmed.")
   def account_is_not_locked, do: dgettext(@domain, "Account is not locked.")
   def account_updated_successfully, do: dgettext(@domain, "Account updated successfully.")
+  def account_created_successfully, do: dgettext(@domain, "Account created successfully.")
   def already_confirmed, do: dgettext(@domain, "already confirmed")
   def already_locked, do: dgettext(@domain, "already locked")
   def already_logged_in, do: dgettext(@domain, "Already logged in.")


### PR DESCRIPTION
When attempting to log in an error would occur as the Html Responder session_create_success expects notice in it's opts and it is never provided.

Added a new "account_created_successfully" message and provided this with the required opts when attempting to log in immediately after creating an account.