### PR TITLE
Add plug 1.6 dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Coherence.Mixfile do
       {:postgrex, ">= 0.0.0", only: :test},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:credo, "~> 0.8", only: [:dev, :test]},
+      {:plug, "~> 1.6"},
     ]
   end
 


### PR DESCRIPTION
`Plug.Conn.get_peer_data/1` is used in /services/trackable_service.ex. This function was not added to Plug.Conn until version 1.6.