### PR TITLE
Confirm email updates improvements

### DIFF
--- a/lib/coherence/controllers/confirmation_controller.ex
+++ b/lib/coherence/controllers/confirmation_controller.ex
@@ -52,7 +52,7 @@ defmodule Coherence.ConfirmationController do
           }
         )
       user ->
-        if user_schema.confirmed?(user) do
+        if user_schema.confirmed?(user) && !(Config.get(:confirm_email_updates) && user.unconfirmed_email) do
           conn
           |> respond_with(
             :confirmation_create_error,

--- a/lib/coherence/controllers/confirmation_controller.ex
+++ b/lib/coherence/controllers/confirmation_controller.ex
@@ -119,8 +119,9 @@ defmodule Coherence.ConfirmationController do
             confirmed_at: NaiveDateTime.utc_now(),
           }))
           case Config.repo.update(changeset) do
-            {:ok, _user} ->
-              conn
+            {:ok, user} ->
+              Config.auth_module
+              |> apply(Config.update_login, [conn, user, [id_key: Config.schema_key]])
               |> respond_with(
                 :confirmation_update_success,
                 %{

--- a/priv/templates/coh.gen.controllers/controllers/coherence/confirmation_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/confirmation_controller.ex
@@ -52,7 +52,7 @@ defmodule <%= web_base %>.Coherence.ConfirmationController do
           }
         )
       user ->
-        if user_schema.confirmed?(user) do
+        if user_schema.confirmed?(user) && !(Config.get(:confirm_email_updates) && user.unconfirmed_email) do
           conn
           |> respond_with(
             :confirmation_create_error,

--- a/priv/templates/coh.gen.controllers/controllers/coherence/confirmation_controller.ex
+++ b/priv/templates/coh.gen.controllers/controllers/coherence/confirmation_controller.ex
@@ -119,8 +119,9 @@ defmodule <%= web_base %>.Coherence.ConfirmationController do
             confirmed_at: NaiveDateTime.utc_now(),
           }))
           case Config.repo.update(changeset) do
-            {:ok, _user} ->
-              conn
+            {:ok, user} ->
+              Config.auth_module
+              |> apply(Config.update_login, [conn, user, [id_key: Config.schema_key]])
               |> respond_with(
                 :confirmation_update_success,
                 %{


### PR DESCRIPTION
Hello,

Some improvements

1/ after confirming a new email, the user should be updated in the credential store to refrect updates on the `unconfirmed_email` attribute
2/ allow to resend email confirmation for unconfirmed emails 
