### PR TITLE
Adjust DbStore.get_user_data to follow other `get_user_data` functions.

### DIFF
--- a/lib/coherence/plugs/authentication/credential_store.ex
+++ b/lib/coherence/plugs/authentication/credential_store.ex
@@ -1,5 +1,5 @@
 defmodule Coherence.CredentialStore do
   @moduledoc false
 
-  @callback get_user_data(String.t() | {String.t(), any, any}) :: any
+  @callback get_user_data(String.t() | {any, String.t(), any}) :: any
 end

--- a/lib/coherence/plugs/authentication/credential_store/session.ex
+++ b/lib/coherence/plugs/authentication/credential_store/session.ex
@@ -33,12 +33,12 @@ defmodule Coherence.CredentialStore.Session do
   Gets the user data for the given credentials
   """
 
-  @spec get_user_data({T.credentials(), nil | struct, integer | nil}) :: any
-  def get_user_data({credentials, nil, _}) do
+  @spec get_user_data({struct, integer | T.credentials(), nil | nil}) :: any
+  def get_user_data({nil, credentials, _}) do
     get_data(credentials)
   end
 
-  def get_user_data({credentials, db_model, id_key}) do
+  def get_user_data({db_model, credentials, id_key}) do
     case get_data(credentials) do
       nil ->
         case DbStore.get_user_data(db_model.__struct__, credentials, id_key) do

--- a/lib/coherence/plugs/authentication/db_store.ex
+++ b/lib/coherence/plugs/authentication/db_store.ex
@@ -13,7 +13,7 @@ defprotocol Coherence.DbStore do
   Get authenticated user data.
   """
   @spec get_user_data(schema, HashDict.t(), atom) :: schema
-  def get_user_data(resource, credentials, id_key)
+  def get_user_data(schema, credentials, id_key)
 
   @doc """
   Save authenticated user data in the database.

--- a/lib/coherence/plugs/authentication/session.ex
+++ b/lib/coherence/plugs/authentication/session.ex
@@ -221,7 +221,7 @@ defmodule Coherence.Authentication.Session do
   defp verify_auth_key({conn, nil}, _, _), do: {conn, nil}
 
   defp verify_auth_key({conn, auth_key}, %{db_model: db_model, id_key: id_key}, store),
-    do: {conn, store.get_user_data({auth_key, db_model, id_key})}
+    do: {conn, store.get_user_data(db_model, auth_key, id_key)}
 
   defp assert_login({%{private: %{phoenix_format: format}} = conn, nil}, login, _opts)
        when format == "json" and (login == true or is_function(login)) do


### PR DESCRIPTION
In Coherence.Authentication.Session
(https://github.com/smpallen99/coherence/blob/master/lib/coherence/plugs/authentication/session.ex#L224)
the function called is with only one param, but the DbStore is with 3
params.

This PR fixes in master version, but old versions have the same problem too.