### PR TITLE
Phoenix 1.4 Upgrade

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Coherence.Mixfile do
 
   defp deps do
     [
-      {:ecto, "~> 2.0"},
+      {:ecto_sql, "~> 3.0"},
       {:comeonin, "~> 4.0"},
       {:bcrypt_elixir, "~> 1.1"},
       {:phoenix, "~> 1.3"},


### PR DESCRIPTION
DO NOT MERGE

This is a work in progress and is working well so far. The big issue is that `Routes` is not defined in the Coherence templates. I'd appreciate any help on getting this PR into good shape.

Done: 
- Updated Ecto to EctoSql 3.0

To Do:
- `Routes` is not available in the Coherence templates. Need to figure out why to use path helpers rather than strings (e.g. `sessions_path/2` vs. "/sessions").