### PR TITLE
Fix typo: seperator -> separator

### DIFF
--- a/priv/templates/coh.install/views/coherence/coherence_view_helpers.ex
+++ b/priv/templates/coh.install/views/coherence/coherence_view_helpers.ex
@@ -21,7 +21,7 @@ defmodule <%= web_base %>.Coherence.ViewHelpers do
   @type conn :: Plug.Conn.t()
   @type schema :: Ecto.Schema.t()
 
-  @seperator {:safe, "&nbsp; | &nbsp;"}
+  @separator {:safe, "&nbsp; | &nbsp;"}
   @helpers <%= web_base %>.Router.Helpers
 
   @recover_link_text "Forgot your password?"
@@ -189,7 +189,7 @@ defmodule <%= web_base %>.Coherence.ViewHelpers do
 
   defp concat([], acc), do: Enum.reverse(acc)
   defp concat([h | t], []), do: concat(t, [h])
-  defp concat([h | t], acc), do: concat(t, [h, @seperator | acc])
+  defp concat([h | t], acc), do: concat(t, [h, @separator | acc])
 
   @doc """
   Generate the recover password link.

--- a/test/support/view_helpers.exs
+++ b/test/support/view_helpers.exs
@@ -9,7 +9,7 @@ defmodule TestCoherenceWeb.ViewHelpers do
   @type conn :: Plug.Conn.t()
   @type schema :: Ecto.Schema.t()
 
-  @seperator {:safe, "&nbsp; | &nbsp;"}
+  @separator {:safe, "&nbsp; | &nbsp;"}
   @helpers Module.concat(Application.get_env(:coherence, :web_module), Router.Helpers)
 
   @recover_link Messages.backend().forgot_your_password()
@@ -142,7 +142,7 @@ defmodule TestCoherenceWeb.ViewHelpers do
 
   defp concat([], acc), do: Enum.reverse(acc)
   defp concat([h | t], []), do: concat(t, [h])
-  defp concat([h | t], acc), do: concat(t, [h, @seperator | acc])
+  defp concat([h | t], acc), do: concat(t, [h, @separator | acc])
 
   @spec recover_link(conn, module, false | String.t()) :: [any] | []
   def recover_link(_conn, _user_schema, false), do: []

--- a/test/support/views.exs
+++ b/test/support/views.exs
@@ -3,7 +3,7 @@ defmodule Coherence.CoherenceView do
   use Phoenix.View, root: "web/templates/coherence"
   import TestCoherenceWeb.Router.Helpers
 
-  @seperator {:safe, "&nbsp; | &nbsp;"}
+  @separator {:safe, "&nbsp; | &nbsp;"}
 
   def coherence_links(conn, :new_session) do
     user_schema = Coherence.Config.user_schema()
@@ -18,7 +18,7 @@ defmodule Coherence.CoherenceView do
 
   defp concat([], acc), do: Enum.reverse(acc)
   defp concat([h | t], []), do: concat(t, [h])
-  defp concat([h | t], acc), do: concat(t, [h, @seperator | acc])
+  defp concat([h | t], acc), do: concat(t, [h, @separator | acc])
 
   defp recovery_link(conn, user_schema) do
     if user_schema.recoverable? do


### PR DESCRIPTION
Fix typo: `seperator` -> `separator`